### PR TITLE
feat(link-checker): add universal link validation plugin

### DIFF
--- a/docs/adr/2025-12-11-link-checker-plugin-extraction.md
+++ b/docs/adr/2025-12-11-link-checker-plugin-extraction.md
@@ -1,0 +1,230 @@
+---
+status: accepted
+date: 2025-12-11
+decision-maker: [Terry Li]
+consulted:
+  [
+    Explore-Architecture,
+    Explore-itp-hooks-Pattern,
+    Explore-Python-Utilities,
+    Plan-LinkChecker,
+    Plan-NotificationTools,
+    Plan-SQLiteMigration,
+  ]
+research-method: 9-agent-parallel-dctl
+clarification-iterations: 4
+perspectives: [ProviderToOtherComponents, EcosystemArtifact]
+---
+
+# ADR: Link Checker Plugin Extraction from Claude-Orchestrator
+
+**Design Spec**: [Implementation Spec](/docs/design/2025-12-11-link-checker-plugin-extraction/spec.md)
+
+## Context and Problem Statement
+
+The `claude-orchestrator` system (~9,000 lines) contains a powerful link validation hook (`check-links-hybrid.sh`, 1,041 lines) that runs lychee on markdown files at session end. This capability is tightly coupled to the orchestrator's Telegram bot, workflow menus, and state management infrastructure.
+
+**Problem**: Users cannot benefit from link validation without installing the entire orchestrator system with its 40+ files, Python dependencies, and Telegram integration.
+
+**Goal**: Extract a standalone, portable link-checker plugin for the cc-skills marketplace that:
+
+1. Works independently of claude-orchestrator
+2. Provides JSON output consumable by other tools
+3. Follows cc-skills plugin conventions (`${CLAUDE_PLUGIN_ROOT}`, hooks.json)
+4. Maintains lychee validation + path policy checking capabilities
+
+### Before/After
+
+**Before: Tightly Coupled**
+
+```
+⏮️ Before: Tightly Coupled
+
+┌─────────────────────┐     ┌───────────────────────┐     ┌──────────────┐     ┌──────┐
+│ claude-orchestrator │     │ check-links-hybrid.sh │     │ Telegram Bot │     │ User │
+│                     │ ──> │     (1,041 lines)     │ ──> │              │ ──> │      │
+└─────────────────────┘     └───────────────────────┘     └──────────────┘     └──────┘
+                              │
+                              │
+                              ∨
+                            ┌───────────────────────┐
+                            │    SessionSummary     │
+                            └───────────────────────┘
+```
+
+<details>
+<summary>graph-easy source</summary>
+
+```
+graph { label: "⏮️ Before: Tightly Coupled"; flow: east; }
+[ claude-orchestrator ] -> [ check-links-hybrid.sh\n(1,041 lines) ] -> [ Telegram Bot ] -> [ User ]
+[ check-links-hybrid.sh\n(1,041 lines) ] -> [ SessionSummary ]
+```
+
+</details>
+
+**After: Decoupled Plugin**
+
+```
+⏭️ After: Decoupled Plugin
+
+┌─────────────────────┐     ╭─────────────────────╮     ┌─────────────┐     ┌──────────────┐
+│ claude-orchestrator │     │ link-checker plugin │     │ JSON Output │     │ Any Consumer │
+│                     │ ··> │    (~300 lines)     │ ──> │             │ ──> │              │
+└─────────────────────┘     ╰─────────────────────╯     └─────────────┘     └──────────────┘
+```
+
+<details>
+<summary>graph-easy source</summary>
+
+```
+graph { label: "⏭️ After: Decoupled Plugin"; flow: east; }
+[ link-checker plugin\n(~300 lines) ] { shape: rounded; } -> [ JSON Output ] -> [ Any Consumer ]
+[ claude-orchestrator ] ..> [ link-checker plugin\n(~300 lines) ]
+```
+
+</details>
+
+## Research Summary
+
+| Agent Perspective         | Key Finding                                                     | Confidence |
+| ------------------------- | --------------------------------------------------------------- | ---------- |
+| Explore-Architecture      | Orchestrator is 3-tier: Hook → Bot → Orchestrator (~9,000 LOC)  | High       |
+| Explore-itp-hooks-Pattern | itp-hooks proves minimal plugin pattern works (~226 lines bash) | High       |
+| Explore-Python-Utilities  | 32 Python files (5,141 lines), 5 have PEP 723 headers           | High       |
+| Plan-LinkChecker          | Python hook (PEP 723) better than 1,041-line bash               | High       |
+| Plan-NotificationTools    | Bot should consume hook output via files (decoupled)            | High       |
+| Plan-SQLiteMigration      | Callbacks migration is independent concern                      | Medium     |
+
+## Decision Log
+
+| Decision Area     | Options Evaluated                     | Chosen            | Rationale                                           |
+| ----------------- | ------------------------------------- | ----------------- | --------------------------------------------------- |
+| Hook language     | Bash (current), Python (PEP 723)      | Python (PEP 723)  | Cleaner than 1,041-line bash, lychee is slow anyway |
+| Output format     | JSON stdout, file only, dual          | JSON + files      | Consumable by other systems                         |
+| Config resolution | Single config, cascade                | Cascade           | Repo → workspace → plugin default flexibility       |
+| Integration point | Stop only, Stop + PostToolUse         | Stop only         | Full validation at session end, avoid per-edit cost |
+| Dependencies      | Pure bash, minimal Python, full stack | Full Python stack | User preference, enables PEP 723 tracing utilities  |
+
+### Trade-offs Accepted
+
+| Trade-off                    | Choice        | Accepted Cost                        |
+| ---------------------------- | ------------- | ------------------------------------ |
+| Simplicity vs Features       | Features      | More code than minimal bash approach |
+| Startup time vs Capability   | Capability    | ~100ms Python startup vs ~5ms bash   |
+| Portability vs Observability | Observability | Requires Python 3.11+ and uv         |
+
+## Decision Drivers
+
+- User wants universal link validation without orchestrator dependency
+- Plugin must work in cc-skills marketplace ecosystem
+- JSON output enables future integrations (Telegram, GitHub Issues, etc.)
+- Existing orchestrator must continue functioning during transition
+
+## Considered Options
+
+- **Option A**: Pure bash minimal hook (~150 lines)
+  - Pro: Fast startup, no Python dependency
+  - Con: Complex JSON handling, limited tracing
+
+- **Option B**: Python hook with PEP 723 (full stack) <- Selected
+  - Pro: Clean code, ULID tracing, event logging
+  - Con: Requires Python 3.11+ and uv
+
+- **Option C**: Keep tightly coupled in orchestrator
+  - Pro: No extraction work needed
+  - Con: Users must install entire orchestrator for link checking
+
+## Decision Outcome
+
+Chosen option: **Option B (Python hook with PEP 723)**, because:
+
+1. User explicitly chose "Keep full Python stack" during planning
+2. Python enables clean lychee subprocess management
+3. PEP 723 inline deps provide self-contained execution (`uv run`)
+4. ULID tracing enables correlation across system components
+5. Lychee is inherently slow (seconds), so Python's ~100ms overhead is negligible
+
+## Synthesis
+
+**Convergent findings**: All perspectives agreed that:
+
+- Link validation should be extractable as standalone plugin
+- Output must be JSON for programmatic consumption
+- Orchestrator's Telegram integration is separate concern
+
+**Divergent findings**:
+
+- Plan-LinkChecker suggested bash might be simpler
+- User preference overrode this for full Python stack
+
+**Resolution**: User decided on Python (PEP 723) with full tracing capabilities.
+
+## Consequences
+
+### Positive
+
+- Universal link validation available to all cc-skills users
+- JSON output enables new integrations without code changes
+- Clear separation of concerns (validation vs notification)
+- Orchestrator can eventually consume plugin output
+
+### Negative
+
+- Requires Python 3.11+ and uv (not just bash)
+- Two link check implementations during transition period
+- Users must install lychee separately
+
+## Architecture
+
+```
+🏗️ Link-Checker Plugin Architecture
+
+                                                 ╭───────────────────────╮
+                                                 │ Claude Code Stop Hook │
+                                                 ╰───────────────────────╯
+                                                   │
+                                                   ∨
+┌────────────────┐     ┌────────────────┐     ┌───────────────────────┐     ┌─────────────┐
+│ Markdown Files │     │ path_linter.py │     │  stop-link-check.py   │     │ ulid_gen.py │
+│                │ <── │                │ <── │       (PEP 723)       │ ──> │             │
+└────────────────┘     └────────────────┘     └───────────────────────┘     └─────────────┘
+                         │                      │
+                         │                      ∨
+                         │                    ┌───────────────────────┐     ┌─────────────┐
+                         │                    │   lychee_runner.py    │ ──> │ lychee CLI  │
+                         │                    └───────────────────────┘     └─────────────┘
+                         │                      │
+                         │                      ∨
+                         │                    ╔═══════════════════════╗
+                         └──────────────────> ║     JSON Results      ║
+                                              ╚═══════════════════════╝
+                                                │
+                                                ∨
+                                              ┌───────────────────────┐
+                                              │    stdout / files     │
+                                              └───────────────────────┘
+```
+
+<details>
+<summary>graph-easy source</summary>
+
+```
+graph { label: "🏗️ Link-Checker Plugin Architecture"; flow: south; }
+[ Claude Code Stop Hook ] { shape: rounded; } -> [ stop-link-check.py\n(PEP 723) ]
+[ stop-link-check.py\n(PEP 723) ] -> [ path_linter.py ] -> [ Markdown Files ]
+[ stop-link-check.py\n(PEP 723) ] -> [ lychee_runner.py ] -> [ lychee CLI ]
+[ stop-link-check.py\n(PEP 723) ] -> [ ulid_gen.py ]
+[ path_linter.py ] -> [ JSON Results ] { shape: dblframe; }
+[ lychee_runner.py ] -> [ JSON Results ]
+[ JSON Results ] -> [ stdout / files ]
+```
+
+</details>
+
+## References
+
+- [Global Plan](/docs/design/2025-12-11-link-checker-plugin-extraction/spec.md) - Full implementation specification
+- [claude-orchestrator](https://github.com/terrylica/claude-orchestrator) - Source system
+- [cc-skills](https://github.com/terrylica/cc-skills) - Target marketplace
+- [itp-hooks pattern](/plugins/itp-hooks/) - Reference plugin architecture

--- a/docs/design/2025-12-11-link-checker-plugin-extraction/spec.md
+++ b/docs/design/2025-12-11-link-checker-plugin-extraction/spec.md
@@ -1,0 +1,309 @@
+---
+title: Link Checker Plugin Extraction
+adr: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+status: implemented
+created: 2025-12-11
+---
+
+# Link Checker Plugin Implementation Specification
+
+**ADR**: [Link Checker Plugin Extraction](/docs/adr/2025-12-11-link-checker-plugin-extraction.md)
+
+## Overview
+
+Extract universal link validation from `claude-orchestrator`'s `check-links-hybrid.sh` (1,041 lines) into a standalone cc-skills marketplace plugin.
+
+## Target Structure
+
+```text
+plugins/link-checker/
+  plugin.json                     # Plugin manifest
+  hooks/
+    hooks.json                    # Hook configuration
+    stop-link-check.py            # Main hook (PEP 723)
+  lib/
+    lychee_runner.py              # Lychee subprocess wrapper
+    path_linter.py                # Path policy validation
+    ulid_gen.py                   # ULID generator (copied)
+    event_logger.py               # Optional tracing (copied)
+  config/
+    lychee.toml                   # Default lychee config
+  README.md                       # User documentation
+  SKILL.md                        # Skill definition
+```
+
+## Component Specifications
+
+### 1. plugin.json
+
+```json
+{
+  "name": "link-checker",
+  "version": "1.0.0",
+  "description": "Universal link validation using lychee for Claude Code sessions",
+  "hooks": "./hooks/hooks.json"
+}
+```
+
+### 2. hooks/hooks.json
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop-link-check.py",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. hooks/stop-link-check.py
+
+Main entry point with PEP 723 inline dependencies.
+
+**Inline Dependencies**:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-ulid>=2.7.0",
+# ]
+# ///
+```
+
+**Core Logic**:
+
+1. Read JSON input from stdin (hook payload)
+2. Check for loop prevention flag (`stop_hook_active`)
+3. Discover markdown files in workspace
+4. Run lychee validation via `lychee_runner.py`
+5. Run path policy validation via `path_linter.py`
+6. Output JSON results to stdout
+7. Optionally write detailed results to file
+
+**Input Schema** (from Claude Code Stop hook):
+
+```json
+{
+  "session_id": "string",
+  "cwd": "string (workspace path)",
+  "stop_hook_active": "boolean (loop prevention)"
+}
+```
+
+**Output Schema**:
+
+```json
+{
+  "status": "pass | fail | error | skipped",
+  "error_count": 0,
+  "lychee_errors": 0,
+  "path_violations": 0,
+  "results_file": "/workspace/.link-check-results.md",
+  "correlation_id": "ULID"
+}
+```
+
+### 4. lib/lychee_runner.py
+
+Subprocess wrapper for lychee CLI.
+
+**Functions**:
+
+- `run_lychee(files: list[Path], config_path: Path | None) -> LycheeResult`
+- `parse_lychee_output(stdout: str, stderr: str) -> list[LinkError]`
+- `find_config(workspace: Path) -> Path | None` (cascade: repo -> workspace -> plugin default)
+
+**Config Resolution Order**:
+
+1. `{workspace}/.lycheerc.toml`
+2. `{workspace}/lychee.toml`
+3. `~/.claude/.lycheerc.toml`
+4. `${CLAUDE_PLUGIN_ROOT}/config/lychee.toml`
+
+### 5. lib/path_linter.py
+
+Validates markdown link paths against policies.
+
+**Functions**:
+
+- `lint_paths(files: list[Path], workspace: Path) -> list[PathViolation]`
+- `check_absolute_paths(content: str) -> list[str]` (detect `/absolute/paths`)
+- `check_relative_escapes(content: str) -> list[str]` (detect `../../` escapes)
+
+**Policy Rules**:
+
+| Rule                 | Description                        | Severity |
+| -------------------- | ---------------------------------- | -------- |
+| NO_ABSOLUTE_PATHS    | Links should be repo-relative      | Warning  |
+| NO_PARENT_ESCAPES    | `../` should not escape repository | Error    |
+| NO_BROKEN_ANCHORS    | `#section` anchors must exist      | Error    |
+| MARKETPLACE_RELATIVE | Plugin files must use `./` paths   | Error    |
+
+### 6. lib/ulid_gen.py
+
+Copy from orchestrator with minimal modifications.
+
+**Source**: `~/.claude/automation/claude-orchestrator/runtime/lib/ulid_gen.py`
+
+**Functions**:
+
+- `generate_ulid() -> str`
+- `ulid_timestamp(ulid: str) -> datetime`
+
+### 7. lib/event_logger.py
+
+Optional tracing for debugging. Copy from orchestrator with configurable DB path.
+
+**Source**: `~/.claude/automation/claude-orchestrator/runtime/lib/event_logger.py`
+
+**Modifications**:
+
+- DB path from env var: `LINK_CHECKER_DB_PATH`
+- Default: `${XDG_STATE_HOME:-~/.local/state}/link-checker/events.db`
+
+### 8. config/lychee.toml
+
+Default configuration bundled with plugin.
+
+**Key Settings**:
+
+```toml
+# Timeout for HTTP requests
+timeout = 30
+
+# Skip these patterns
+exclude = [
+  "^https://localhost",
+  "^file://",
+  "^mailto:",
+]
+
+# Accept these status codes
+accept = [200, 204, 301, 302]
+
+# GitHub rate limiting
+max_concurrency = 4
+
+# Cache settings
+cache = true
+```
+
+## Integration Points
+
+### With Claude Code
+
+- **Hook Event**: Stop (session end)
+- **Loop Prevention**: Check `stop_hook_active` in input
+- **Exit Codes**: 0 = success/skipped, 1 = errors found
+
+### With claude-orchestrator (Optional)
+
+The orchestrator can consume plugin output by:
+
+1. Reading JSON from stdout
+2. Reading detailed results file
+3. Correlating via ULID
+
+This enables gradual migration without breaking existing workflows.
+
+## Testing Strategy
+
+### Unit Tests
+
+```bash
+# Test lychee runner
+uv run pytest tests/test_lychee_runner.py
+
+# Test path linter
+uv run pytest tests/test_path_linter.py
+```
+
+### Integration Test
+
+```bash
+# Simulate Stop hook
+cd /path/to/workspace
+echo '{"cwd": "'"$(pwd)"'", "session_id": "test"}' | \
+  uv run plugins/link-checker/hooks/stop-link-check.py
+```
+
+### Manual Validation
+
+```bash
+# Check plugin loads
+claude --print-plugins | grep link-checker
+
+# Trigger Stop hook manually
+# (create session, make changes, exit)
+```
+
+## Migration from Orchestrator
+
+### Phase 1: Parallel Operation
+
+1. Install link-checker plugin
+2. Keep orchestrator hook active
+3. Compare outputs for consistency
+
+### Phase 2: Orchestrator Consumption
+
+1. Modify orchestrator to read plugin output
+2. Disable orchestrator's own link checking
+3. Keep Telegram notifications via plugin output
+
+### Phase 3: Full Independence
+
+1. Remove link-checking code from orchestrator
+2. Plugin operates standalone
+3. Any consumer can use JSON output
+
+## Dependencies
+
+### Required
+
+- Python 3.11+
+- uv (package manager)
+- lychee (Rust link checker)
+- git (for workspace detection)
+
+### Python (PEP 723 inline)
+
+- python-ulid>=2.7.0
+
+## Security Considerations
+
+- No network access except lychee's link checking
+- No file writes except optional results file
+- No credential access required
+- Sandbox-compatible execution
+
+## Error Handling
+
+| Error                | Behavior                       | Exit Code |
+| -------------------- | ------------------------------ | --------- |
+| lychee not installed | Log warning, return skipped    | 0         |
+| No markdown files    | Return pass (nothing to check) | 0         |
+| lychee timeout       | Log error, return error status | 0         |
+| Invalid JSON input   | Log error, return error status | 1         |
+| Path lint violations | Return fail with details       | 0         |
+| Link check failures  | Return fail with details       | 0         |
+
+## Success Metrics
+
+- [ ] Plugin installs via cc-skills marketplace
+- [ ] Works without claude-orchestrator installed
+- [ ] JSON output consumable by external tools
+- [ ] Lychee validation matches orchestrator behavior
+- [ ] Path linting catches policy violations
+- [ ] Documentation complete (README.md, SKILL.md)

--- a/plugins/link-checker/README.md
+++ b/plugins/link-checker/README.md
@@ -1,0 +1,135 @@
+# Link Checker Plugin
+
+Universal link validation for Claude Code sessions using [lychee](https://github.com/lycheeverse/lychee).
+
+**ADR**: [Link Checker Plugin Extraction](./../../docs/adr/2025-12-11-link-checker-plugin-extraction.md)
+
+## Features
+
+- **Lychee Integration**: Validates markdown links at session end
+- **Path Policy Linting**: Detects absolute paths and excessive parent traversal
+- **JSON Output**: Programmatic results for integration with other tools
+- **Configurable**: Cascade config resolution (repo -> workspace -> plugin default)
+- **ULID Tracing**: Correlation IDs for debugging across systems
+
+## Installation
+
+This plugin is part of the cc-skills marketplace. Install via:
+
+```bash
+# From cc-skills marketplace
+claude /plugin install cc-skills
+```
+
+Or add to your Claude Code settings manually.
+
+## Requirements
+
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv) (Python package manager)
+- [lychee](https://github.com/lycheeverse/lychee) (optional, for link validation)
+
+Install lychee:
+
+```bash
+# macOS
+brew install lychee
+
+# Cargo
+cargo install lychee
+```
+
+## Usage
+
+The plugin runs automatically at session end (Stop hook). No manual invocation needed.
+
+### Output
+
+Results are output as JSON to stdout:
+
+```json
+{
+  "status": "pass",
+  "error_count": 0,
+  "lychee_errors": 0,
+  "path_violations": 0,
+  "correlation_id": "01JEGQXV8KHTNF3YD8G7ZC9XYK",
+  "results_file": "/path/to/workspace/.link-check-results.md"
+}
+```
+
+### Status Values
+
+| Status    | Meaning                               |
+| --------- | ------------------------------------- |
+| `pass`    | No errors found                       |
+| `fail`    | Broken links or path violations found |
+| `skipped` | Validation skipped (loop prevention)  |
+| `error`   | Execution error (invalid input, etc.) |
+
+## Configuration
+
+### Lychee Config
+
+The plugin searches for lychee configuration in this order:
+
+1. `{workspace}/.lycheerc.toml`
+2. `{workspace}/lychee.toml`
+3. `~/.claude/.lycheerc.toml`
+4. Plugin default (`config/lychee.toml`)
+
+### Path Policy Rules
+
+| Rule                 | Severity | Description                                |
+| -------------------- | -------- | ------------------------------------------ |
+| NO_ABSOLUTE_PATHS    | Error    | `/Users/...` or `/home/...` paths detected |
+| NO_PARENT_ESCAPES    | Warning  | Excessive `../` traversal (5+ levels)      |
+| MARKETPLACE_RELATIVE | Warning  | Plugin files should use relative paths     |
+
+## Manual Testing
+
+Test the hook directly:
+
+```bash
+cd /path/to/workspace
+echo '{"cwd": "'"$(pwd)"'"}' | uv run ~/.claude/plugins/marketplaces/cc-skills/plugins/link-checker/hooks/stop-link-check.py
+```
+
+## Architecture
+
+```text
+plugins/link-checker/
+  plugin.json           # Plugin manifest
+  hooks/
+    hooks.json          # Hook configuration (Stop event)
+    stop-link-check.py  # Main hook script (PEP 723)
+  lib/
+    __init__.py
+    ulid_gen.py         # ULID generation
+    lychee_runner.py    # Lychee subprocess wrapper
+    path_linter.py      # Path policy validation
+  config/
+    lychee.toml         # Default lychee configuration
+```
+
+## Integration
+
+### With claude-orchestrator
+
+The orchestrator can consume plugin output by:
+
+1. Reading JSON from hook stdout
+2. Reading `.link-check-results.md` for details
+3. Correlating via ULID
+
+### With Other Tools
+
+JSON output enables integration with:
+
+- CI/CD pipelines
+- Notification systems (Telegram, Slack)
+- Issue trackers (GitHub Issues)
+
+## License
+
+MIT

--- a/plugins/link-checker/config/lychee.toml
+++ b/plugins/link-checker/config/lychee.toml
@@ -1,0 +1,43 @@
+# Lychee Link Checker Configuration
+# Plugin: link-checker
+# ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+#
+# This is the default configuration bundled with the plugin.
+# Override by placing .lycheerc.toml or lychee.toml in your workspace.
+
+############################# Display ###############################
+verbose = "error"      # Only show errors
+no_progress = true     # Required for non-interactive shells
+
+############################# Cache #################################
+cache = true                        # Enable response caching (.lycheecache)
+max_cache_age = "7d"                # Weekly cache expiration
+cache_exclude_status = "429,500..=599"  # Don't cache rate limits/server errors
+
+############################# Runtime ###############################
+timeout = 5                 # Fast timeout (offline mode, local files only)
+max_retries = 1             # Minimal retries (validation is idempotent)
+max_concurrency = 4         # Moderate parallelism
+
+############################# Features ##############################
+offline = true              # Only check local files (no network requests)
+include_fragments = true    # Validate anchor fragments (#section)
+include_verbatim = false    # Skip code blocks (intended behavior)
+include_mail = false        # Disable email validation
+
+############################# Exclusions ############################
+exclude_path = [
+    "node_modules/",
+    "\\.git/",
+    "file-history/",
+    "plugins/marketplaces/",
+    "todos/.*\\.json$",
+    "\\.venv/",
+    "backups/",
+    "__pycache__/",
+]
+
+# Exclude patterns (regex) - applied to link URLs
+exclude = [
+    "^mailto:",  # Skip email links entirely
+]

--- a/plugins/link-checker/hooks/hooks.json
+++ b/plugins/link-checker/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop-link-check.py",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/link-checker/hooks/stop-link-check.py
+++ b/plugins/link-checker/hooks/stop-link-check.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-ulid>=2.7.0",
+#     "typing-extensions>=4.0.0",
+# ]
+# ///
+"""
+Link Checker Stop Hook
+
+Universal link validation for Claude Code sessions using lychee.
+Runs at session end (Stop hook event).
+
+ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+
+Features:
+- Lychee link validation (broken links, redirects)
+- Path policy validation (relative paths in plugins)
+- JSON output for programmatic consumption
+- ULID correlation IDs for tracing
+
+Exit codes:
+- 0: Success (pass, skipped, or graceful error)
+- 1: Hard error (invalid input)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from ulid import ULID
+
+
+def generate_ulid() -> str:
+    """Generate a ULID for correlation."""
+    return str(ULID())
+
+
+def find_lychee_config(workspace: Path, plugin_root: Path) -> Path | None:
+    """
+    Find lychee config using cascade resolution.
+
+    Resolution order:
+    1. {workspace}/.lycheerc.toml
+    2. {workspace}/lychee.toml
+    3. ~/.claude/.lycheerc.toml
+    4. ${CLAUDE_PLUGIN_ROOT}/config/lychee.toml
+    """
+    candidates = [
+        workspace / ".lycheerc.toml",
+        workspace / "lychee.toml",
+        Path.home() / ".claude" / ".lycheerc.toml",
+        plugin_root / "config" / "lychee.toml",
+    ]
+
+    for config in candidates:
+        if config.exists():
+            return config
+
+    return None
+
+
+def find_git_root(workspace: Path) -> Path | None:
+    """Find git repository root from workspace."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def discover_markdown_files(workspace: Path) -> list[Path]:
+    """Discover markdown files in workspace."""
+    md_files: list[Path] = []
+
+    # Exclusion patterns (aligned with lychee config)
+    exclude_dirs = {
+        "node_modules",
+        ".git",
+        "file-history",
+        "plugins/marketplaces",
+        ".venv",
+        "backups",
+        "__pycache__",
+    }
+
+    for md_file in workspace.rglob("*.md"):
+        # Check if file is in excluded directory
+        parts = set(md_file.relative_to(workspace).parts[:-1])
+        if not parts.intersection(exclude_dirs):
+            md_files.append(md_file)
+
+    return md_files
+
+
+def run_lychee(
+    files: list[Path],
+    workspace: Path,
+    config_path: Path | None,
+) -> dict[str, Any]:
+    """
+    Run lychee on markdown files.
+
+    Returns dict with:
+    - ran: bool (whether lychee executed)
+    - error_count: int (number of broken links)
+    - errors: list[str] (error messages)
+    """
+    # Check if lychee is installed
+    if subprocess.run(["which", "lychee"], capture_output=True).returncode != 0:
+        return {
+            "ran": False,
+            "error_count": 0,
+            "errors": [],
+            "skipped_reason": "lychee not installed",
+        }
+
+    if not files:
+        return {
+            "ran": True,
+            "error_count": 0,
+            "errors": [],
+            "skipped_reason": "no markdown files found",
+        }
+
+    # Build lychee command
+    cmd = ["lychee", "--format", "json"]
+
+    if config_path:
+        cmd.extend(["--config", str(config_path)])
+
+    # Add root directory for repo-relative link resolution
+    cmd.extend(["--root-dir", str(workspace)])
+
+    # Add files
+    cmd.extend(str(f) for f in files[:100])  # Limit to avoid arg length issues
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, "NO_COLOR": "1"},
+        )
+
+        # Parse JSON output
+        errors: list[str] = []
+        error_count = 0
+
+        if result.stdout.strip():
+            try:
+                lychee_output = json.loads(result.stdout)
+                # Lychee JSON format: {"fail_map": {"file.md": [{"url": ..., "status": ...}]}}
+                fail_map = lychee_output.get("fail_map", {})
+                for file_path, failures in fail_map.items():
+                    for failure in failures:
+                        url = failure.get("url", "unknown")
+                        status = failure.get("status", {})
+                        error_count += 1
+                        errors.append(f"{file_path}: {url} - {status}")
+            except json.JSONDecodeError:
+                # Fallback: count non-zero exit as error
+                if result.returncode != 0:
+                    error_count = 1
+                    errors.append(result.stderr or "lychee returned non-zero")
+
+        return {
+            "ran": True,
+            "error_count": error_count,
+            "errors": errors,
+        }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "ran": True,
+            "error_count": 0,
+            "errors": ["lychee timed out after 60s"],
+            "skipped_reason": "timeout",
+        }
+    except Exception as e:
+        return {
+            "ran": False,
+            "error_count": 0,
+            "errors": [str(e)],
+            "skipped_reason": f"error: {e}",
+        }
+
+
+def lint_paths(files: list[Path], workspace: Path) -> list[dict[str, Any]]:
+    """
+    Lint markdown files for path policy violations.
+
+    Checks:
+    - Absolute paths (/Users/...) in links
+    - Parent escapes (../../..) that leave the repository
+
+    Returns list of violations.
+    """
+    import re
+
+    violations: list[dict[str, Any]] = []
+
+    # Regex patterns for markdown links
+    link_pattern = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
+    for file_path in files:
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+
+        for match in link_pattern.finditer(content):
+            link_text, link_url = match.groups()
+
+            # Skip external URLs and anchors
+            if link_url.startswith(("http://", "https://", "mailto:", "#")):
+                continue
+
+            # Check for absolute filesystem paths
+            if link_url.startswith("/Users/") or link_url.startswith("/home/"):
+                violations.append({
+                    "file": str(file_path.relative_to(workspace)),
+                    "rule": "NO_ABSOLUTE_PATHS",
+                    "severity": "error",
+                    "link": link_url,
+                    "message": f"Absolute filesystem path detected: {link_url}",
+                })
+
+            # Check for excessive parent traversal
+            if link_url.count("../") >= 5:
+                violations.append({
+                    "file": str(file_path.relative_to(workspace)),
+                    "rule": "NO_PARENT_ESCAPES",
+                    "severity": "warning",
+                    "link": link_url,
+                    "message": f"Excessive parent traversal (5+ levels): {link_url}",
+                })
+
+    return violations
+
+
+def write_results_file(
+    workspace: Path,
+    lychee_result: dict[str, Any],
+    path_violations: list[dict[str, Any]],
+    correlation_id: str,
+) -> Path | None:
+    """Write detailed results to workspace file."""
+    results_file = workspace / ".link-check-results.md"
+
+    try:
+        lines = [
+            "# Link Check Results",
+            "",
+            f"**Correlation ID**: `{correlation_id}`",
+            f"**Timestamp**: {__import__('datetime').datetime.now().isoformat()}",
+            "",
+        ]
+
+        # Lychee results
+        lines.append("## Lychee Link Validation")
+        lines.append("")
+
+        if not lychee_result.get("ran"):
+            reason = lychee_result.get("skipped_reason", "unknown")
+            lines.append(f"*Skipped*: {reason}")
+        elif lychee_result.get("error_count", 0) == 0:
+            lines.append("No broken links found.")
+        else:
+            lines.append(f"Found **{lychee_result['error_count']}** broken link(s):")
+            lines.append("")
+            for error in lychee_result.get("errors", [])[:20]:
+                lines.append(f"- {error}")
+
+        lines.append("")
+
+        # Path violations
+        lines.append("## Path Policy Violations")
+        lines.append("")
+
+        if not path_violations:
+            lines.append("No path violations found.")
+        else:
+            lines.append(f"Found **{len(path_violations)}** violation(s):")
+            lines.append("")
+            for v in path_violations[:20]:
+                lines.append(f"- **{v['rule']}** ({v['severity']}): {v['file']}")
+                lines.append(f"  - {v['message']}")
+
+        results_file.write_text("\n".join(lines), encoding="utf-8")
+        return results_file
+
+    except Exception:
+        return None
+
+
+def main() -> int:
+    """Main entry point for Stop hook."""
+    # Read hook input from stdin
+    try:
+        hook_input = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError:
+        # Invalid JSON - hard error
+        print(json.dumps({
+            "status": "error",
+            "error_count": 0,
+            "message": "Invalid JSON input",
+        }))
+        return 1
+
+    # Check loop prevention flag
+    if hook_input.get("stop_hook_active", False):
+        print(json.dumps({
+            "status": "skipped",
+            "error_count": 0,
+            "message": "Stop hook already active (loop prevention)",
+        }))
+        return 0
+
+    # Determine workspace
+    workspace_str = hook_input.get("cwd") or os.environ.get("CLAUDE_WORKSPACE_DIR", "")
+    if not workspace_str:
+        workspace_str = str(Path.home() / ".claude")
+
+    workspace = Path(workspace_str)
+    if not workspace.exists():
+        print(json.dumps({
+            "status": "error",
+            "error_count": 0,
+            "message": f"Workspace does not exist: {workspace}",
+        }))
+        return 0  # Graceful exit
+
+    # Find git root (for repo-relative link resolution)
+    git_root = find_git_root(workspace)
+    effective_root = git_root or workspace
+
+    # Determine plugin root
+    plugin_root_str = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    if plugin_root_str:
+        plugin_root = Path(plugin_root_str)
+    else:
+        # Fallback: derive from this script's location
+        plugin_root = Path(__file__).parent.parent
+
+    # Generate correlation ID
+    correlation_id = generate_ulid()
+
+    # Find lychee config
+    config_path = find_lychee_config(effective_root, plugin_root)
+
+    # Discover markdown files
+    md_files = discover_markdown_files(effective_root)
+
+    # Run lychee
+    lychee_result = run_lychee(md_files, effective_root, config_path)
+
+    # Run path linter
+    path_violations = lint_paths(md_files, effective_root)
+
+    # Write results file
+    results_file = write_results_file(
+        effective_root,
+        lychee_result,
+        path_violations,
+        correlation_id,
+    )
+
+    # Calculate totals
+    lychee_errors = lychee_result.get("error_count", 0)
+    path_errors = len([v for v in path_violations if v["severity"] == "error"])
+    total_errors = lychee_errors + path_errors
+
+    # Determine status
+    if not lychee_result.get("ran") and not md_files:
+        status = "skipped"
+    elif total_errors > 0:
+        status = "fail"
+    else:
+        status = "pass"
+
+    # Output JSON result
+    result = {
+        "status": status,
+        "error_count": total_errors,
+        "lychee_errors": lychee_errors,
+        "path_violations": len(path_violations),
+        "correlation_id": correlation_id,
+    }
+
+    if results_file:
+        result["results_file"] = str(results_file)
+
+    if lychee_result.get("skipped_reason"):
+        result["lychee_skipped"] = lychee_result["skipped_reason"]
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/link-checker/lib/__init__.py
+++ b/plugins/link-checker/lib/__init__.py
@@ -1,0 +1,9 @@
+"""Link Checker Plugin Library.
+
+ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+
+This package provides utilities for:
+- ULID generation for correlation IDs
+- Lychee subprocess management
+- Path policy linting
+"""

--- a/plugins/link-checker/lib/lychee_runner.py
+++ b/plugins/link-checker/lib/lychee_runner.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Lychee Subprocess Runner
+
+Wrapper for running lychee link checker as a subprocess.
+
+ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class LycheeResult:
+    """Result from lychee execution."""
+
+    ran: bool
+    error_count: int
+    errors: list[str] = field(default_factory=list)
+    skipped_reason: str | None = None
+
+
+def find_config(workspace: Path, plugin_root: Path | None = None) -> Path | None:
+    """
+    Find lychee config using cascade resolution.
+
+    Resolution order:
+    1. {workspace}/.lycheerc.toml
+    2. {workspace}/lychee.toml
+    3. ~/.claude/.lycheerc.toml
+    4. ${CLAUDE_PLUGIN_ROOT}/config/lychee.toml (if plugin_root provided)
+
+    Args:
+        workspace: Workspace directory to search
+        plugin_root: Optional plugin root for fallback config
+
+    Returns:
+        Path to config file, or None if not found
+    """
+    candidates = [
+        workspace / ".lycheerc.toml",
+        workspace / "lychee.toml",
+        Path.home() / ".claude" / ".lycheerc.toml",
+    ]
+
+    if plugin_root:
+        candidates.append(plugin_root / "config" / "lychee.toml")
+
+    for config in candidates:
+        if config.exists():
+            return config
+
+    return None
+
+
+def is_lychee_installed() -> bool:
+    """Check if lychee is available in PATH."""
+    try:
+        result = subprocess.run(
+            ["which", "lychee"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
+
+def run_lychee(
+    files: list[Path],
+    workspace: Path,
+    config_path: Path | None = None,
+    timeout: int = 60,
+) -> LycheeResult:
+    """
+    Run lychee on markdown files.
+
+    Args:
+        files: List of markdown files to check
+        workspace: Workspace root for --root-dir
+        config_path: Optional path to lychee config
+        timeout: Timeout in seconds (default 60)
+
+    Returns:
+        LycheeResult with execution details
+    """
+    if not is_lychee_installed():
+        return LycheeResult(
+            ran=False,
+            error_count=0,
+            skipped_reason="lychee not installed",
+        )
+
+    if not files:
+        return LycheeResult(
+            ran=True,
+            error_count=0,
+            skipped_reason="no files to check",
+        )
+
+    # Build command
+    cmd = ["lychee", "--format", "json"]
+
+    if config_path:
+        cmd.extend(["--config", str(config_path)])
+
+    # Add root directory for repo-relative link resolution
+    cmd.extend(["--root-dir", str(workspace)])
+
+    # Limit files to avoid argument length issues
+    cmd.extend(str(f) for f in files[:100])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={**os.environ, "NO_COLOR": "1"},
+        )
+
+        return parse_lychee_output(result.stdout, result.stderr, result.returncode)
+
+    except subprocess.TimeoutExpired:
+        return LycheeResult(
+            ran=True,
+            error_count=0,
+            errors=[f"lychee timed out after {timeout}s"],
+            skipped_reason="timeout",
+        )
+    except Exception as e:
+        return LycheeResult(
+            ran=False,
+            error_count=0,
+            errors=[str(e)],
+            skipped_reason=f"error: {e}",
+        )
+
+
+def parse_lychee_output(
+    stdout: str,
+    stderr: str,
+    returncode: int,
+) -> LycheeResult:
+    """
+    Parse lychee JSON output.
+
+    Lychee JSON format:
+    {
+        "fail_map": {
+            "file.md": [{"url": "...", "status": {...}}]
+        }
+    }
+    """
+    errors: list[str] = []
+    error_count = 0
+
+    if stdout.strip():
+        try:
+            output: dict[str, Any] = json.loads(stdout)
+            fail_map = output.get("fail_map", {})
+
+            for file_path, failures in fail_map.items():
+                for failure in failures:
+                    url = failure.get("url", "unknown")
+                    status = failure.get("status", {})
+                    error_count += 1
+                    errors.append(f"{file_path}: {url} - {status}")
+
+        except json.JSONDecodeError:
+            # Fallback: non-zero exit means errors
+            if returncode != 0:
+                error_count = 1
+                errors.append(stderr or "lychee returned non-zero")
+
+    return LycheeResult(
+        ran=True,
+        error_count=error_count,
+        errors=errors,
+    )
+
+
+if __name__ == "__main__":
+    # Simple CLI for testing
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: lychee_runner.py <workspace>")
+        sys.exit(1)
+
+    workspace = Path(sys.argv[1])
+    files = list(workspace.rglob("*.md"))[:10]
+
+    result = run_lychee(files, workspace)
+    print(f"Ran: {result.ran}")
+    print(f"Errors: {result.error_count}")
+    if result.skipped_reason:
+        print(f"Skipped: {result.skipped_reason}")
+    for error in result.errors[:5]:
+        print(f"  - {error}")

--- a/plugins/link-checker/lib/path_linter.py
+++ b/plugins/link-checker/lib/path_linter.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""
+Path Policy Linter
+
+Validates markdown link paths against project policies.
+
+ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+
+Policy Rules:
+- NO_ABSOLUTE_PATHS: Links should not use filesystem absolute paths
+- NO_PARENT_ESCAPES: Excessive ../ traversal may escape repository
+- MARKETPLACE_RELATIVE: Plugin files should use relative paths
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class PathViolation:
+    """A path policy violation."""
+
+    file: str
+    rule: str
+    severity: Literal["error", "warning"]
+    link: str
+    message: str
+
+
+# Regex pattern for markdown links: [text](url)
+LINK_PATTERN = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
+
+
+def check_absolute_paths(content: str) -> list[str]:
+    """
+    Detect absolute filesystem paths in markdown links.
+
+    Args:
+        content: Markdown file content
+
+    Returns:
+        List of absolute path links found
+    """
+    absolute_paths: list[str] = []
+
+    for match in LINK_PATTERN.finditer(content):
+        _, link_url = match.groups()
+
+        # Skip external URLs and anchors
+        if link_url.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+
+        # Check for absolute filesystem paths
+        if link_url.startswith("/Users/") or link_url.startswith("/home/"):
+            absolute_paths.append(link_url)
+
+    return absolute_paths
+
+
+def check_relative_escapes(content: str, max_levels: int = 5) -> list[str]:
+    """
+    Detect excessive parent directory traversal in links.
+
+    Args:
+        content: Markdown file content
+        max_levels: Maximum allowed ../ levels (default 5)
+
+    Returns:
+        List of links with excessive parent traversal
+    """
+    escapes: list[str] = []
+
+    for match in LINK_PATTERN.finditer(content):
+        _, link_url = match.groups()
+
+        # Skip external URLs and anchors
+        if link_url.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+
+        # Count parent traversals
+        if link_url.count("../") >= max_levels:
+            escapes.append(link_url)
+
+    return escapes
+
+
+def check_marketplace_relative(
+    content: str,
+    file_path: Path,
+    workspace: Path,
+) -> list[str]:
+    """
+    Check if plugin files use relative paths correctly.
+
+    Plugin files (in plugins/ directories) should use ./ or ../ relative paths,
+    not repo-root absolute paths starting with /.
+
+    Args:
+        content: Markdown file content
+        file_path: Path to the file being checked
+        workspace: Workspace root
+
+    Returns:
+        List of violating links (repo-absolute in plugin context)
+    """
+    violations: list[str] = []
+
+    # Check if file is in a plugins directory
+    try:
+        rel_path = file_path.relative_to(workspace)
+        parts = rel_path.parts
+    except ValueError:
+        return violations
+
+    # Only check files under plugins/
+    if "plugins" not in parts:
+        return violations
+
+    for match in LINK_PATTERN.finditer(content):
+        _, link_url = match.groups()
+
+        # Skip external URLs and anchors
+        if link_url.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+
+        # In plugin context, links starting with / are repo-absolute
+        # They should be ./ or ../ relative instead
+        if link_url.startswith("/") and not link_url.startswith("/Users"):
+            violations.append(link_url)
+
+    return violations
+
+
+def lint_paths(
+    files: list[Path],
+    workspace: Path,
+    check_marketplace: bool = True,
+) -> list[PathViolation]:
+    """
+    Lint markdown files for path policy violations.
+
+    Args:
+        files: List of markdown files to check
+        workspace: Workspace root directory
+        check_marketplace: Whether to check marketplace relative path rules
+
+    Returns:
+        List of PathViolation objects
+    """
+    violations: list[PathViolation] = []
+
+    for file_path in files:
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+
+        try:
+            rel_file = str(file_path.relative_to(workspace))
+        except ValueError:
+            rel_file = str(file_path)
+
+        # Check absolute paths
+        for link in check_absolute_paths(content):
+            violations.append(PathViolation(
+                file=rel_file,
+                rule="NO_ABSOLUTE_PATHS",
+                severity="error",
+                link=link,
+                message=f"Absolute filesystem path detected: {link}",
+            ))
+
+        # Check parent escapes
+        for link in check_relative_escapes(content):
+            violations.append(PathViolation(
+                file=rel_file,
+                rule="NO_PARENT_ESCAPES",
+                severity="warning",
+                link=link,
+                message=f"Excessive parent traversal (5+ levels): {link}",
+            ))
+
+        # Check marketplace relative paths
+        if check_marketplace:
+            for link in check_marketplace_relative(content, file_path, workspace):
+                violations.append(PathViolation(
+                    file=rel_file,
+                    rule="MARKETPLACE_RELATIVE",
+                    severity="warning",
+                    link=link,
+                    message=f"Plugin file uses repo-absolute path (should be relative): {link}",
+                ))
+
+    return violations
+
+
+if __name__ == "__main__":
+    # Simple CLI for testing
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: path_linter.py <workspace>")
+        sys.exit(1)
+
+    workspace = Path(sys.argv[1])
+    files = list(workspace.rglob("*.md"))[:20]
+
+    violations = lint_paths(files, workspace)
+
+    if not violations:
+        print("No path violations found.")
+        sys.exit(0)
+
+    print(f"Found {len(violations)} violation(s):\n")
+    for v in violations:
+        print(f"[{v.severity.upper()}] {v.rule}")
+        print(f"  File: {v.file}")
+        print(f"  Link: {v.link}")
+        print(f"  {v.message}\n")
+
+    sys.exit(1 if any(v.severity == "error" for v in violations) else 0)

--- a/plugins/link-checker/lib/ulid_gen.py
+++ b/plugins/link-checker/lib/ulid_gen.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-ulid>=2.7.0",
+# ]
+# ///
+"""
+ULID Generator
+
+Generates ULID (Universally Unique Lexicographically Sortable Identifier).
+Used for correlation IDs in event tracking.
+
+ADR: /docs/adr/2025-12-11-link-checker-plugin-extraction.md
+Source: Adapted from claude-orchestrator/runtime/lib/ulid_gen.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+from ulid import ULID
+
+
+def generate() -> str:
+    """
+    Generate ULID.
+
+    Returns:
+        26-character ULID string (e.g., 01JEGQXV8KHTNF3YD8G7ZC9XYK)
+    """
+    return str(ULID())
+
+
+def main() -> int:
+    """CLI entry point."""
+    print(generate())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/link-checker/plugin.json
+++ b/plugins/link-checker/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "link-checker",
+  "version": "1.0.0",
+  "description": "Universal link validation using lychee for Claude Code sessions",
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/link-checker/skills/link-validation/SKILL.md
+++ b/plugins/link-checker/skills/link-validation/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: link-validation
+description: Universal link validation using lychee for Claude Code sessions. Runs at session end to detect broken links and path policy violations.
+triggers:
+  - link validation
+  - broken links
+  - lychee
+  - check links
+  - markdown links
+---
+
+# Link Validation Skill
+
+Validates markdown links in your workspace using [lychee](https://github.com/lycheeverse/lychee).
+
+## What It Does
+
+At session end (Stop hook), this skill:
+
+1. **Discovers** all markdown files in your workspace
+2. **Runs lychee** to check for broken links
+3. **Lints paths** for policy violations (absolute paths, excessive traversal)
+4. **Outputs JSON** results for programmatic consumption
+
+## Requirements
+
+- [lychee](https://github.com/lycheeverse/lychee) installed (`brew install lychee`)
+- Python 3.11+ and uv
+
+## Output
+
+Results are written to `.link-check-results.md` in your workspace:
+
+```markdown
+# Link Check Results
+
+**Correlation ID**: `01JEGQXV8KHTNF3YD8G7ZC9XYK`
+
+## Lychee Link Validation
+
+No broken links found.
+
+## Path Policy Violations
+
+No path violations found.
+```
+
+## Path Policy Rules
+
+| Rule                 | Severity | Description                            |
+| -------------------- | -------- | -------------------------------------- |
+| NO_ABSOLUTE_PATHS    | Error    | Filesystem absolute paths not allowed  |
+| NO_PARENT_ESCAPES    | Warning  | Excessive `../` may escape repository  |
+| MARKETPLACE_RELATIVE | Warning  | Plugins should use `./` relative paths |
+
+## Configuration
+
+Override the default lychee config by placing `.lycheerc.toml` in your workspace root.
+
+See [./config/lychee.toml](./../../config/lychee.toml) for the default configuration.
+
+## References
+
+- [ADR: Link Checker Plugin Extraction](./../../docs/adr/2025-12-11-link-checker-plugin-extraction.md)
+- [Design Spec](./../../docs/design/2025-12-11-link-checker-plugin-extraction/spec.md)
+- [lychee Documentation](https://github.com/lycheeverse/lychee)


### PR DESCRIPTION
## Summary

- Extract link validation from `claude-orchestrator` into standalone cc-skills plugin
- Implement Stop hook with PEP 723 inline dependencies (Python 3.11+)
- Add lychee integration for broken link detection
- Add path policy linting (absolute paths, parent traversal)
- JSON output enables integration with other tools

## Architecture

The plugin runs at session end (Stop hook) and validates all markdown files:

1. **Lychee validation**: Checks for broken links, redirects
2. **Path policy linting**: Detects absolute paths (`/Users/...`) and excessive `../` traversal
3. **JSON output**: Programmatic results for CI/CD, notifications, etc.

## Test Plan

- [x] Plugin loads and executes standalone
- [x] Lychee integration works (when installed)
- [x] Path linter detects violations
- [x] JSON output is valid and complete
- [x] Loop prevention (`stop_hook_active`) works

## ADR

- [ADR: Link Checker Plugin Extraction](/docs/adr/2025-12-11-link-checker-plugin-extraction.md)
- [Design Spec](/docs/design/2025-12-11-link-checker-plugin-extraction/spec.md)