### PR TITLE
Add Skills宝 as a Chinese install entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ git clone https://github.com/terrylica/cc-skills.git /tmp/cc-skills
 claude
 ```
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ### Step-by-Step Installation
 
 #### Step 1: Add the Marketplace


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the Claude Code marketplace installation flow and gives Chinese users a faster entry point to the skill catalog.