### PR TITLE
fix(itp-hooks): bound stdin reads with timeout to stop fork-storm/SIGTRAP under load

### DIFF
--- a/plugins/itp-hooks/hooks/lib/stdin-timeout.ts
+++ b/plugins/itp-hooks/hooks/lib/stdin-timeout.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared stdin-read timeout guard for itp-hooks.
+ *
+ * Root cause this fixes: `await Bun.stdin.text()` (and `Bun.stdin.stream()`)
+ * block FOREVER when the parent never closes stdin's write end. Observed under
+ * heavy container load — a full fan-out of PreToolUse guards stuck in `Sl` sleep
+ * for ~59min, each leaking ~31MB → memory pressure → fresh bun spawns SIGTRAP
+ * (core dump). Bounding the read with a hard deadline lets the hook fail open
+ * (hooks are advisory; a missed read must never hang the tool call).
+ *
+ * Tune via env: ITP_HOOK_STDIN_TIMEOUT_MS (default 2000).
+ */
+
+export const STDIN_READ_TIMEOUT_MS =
+  Number(process.env.ITP_HOOK_STDIN_TIMEOUT_MS) || 2000;
+
+/**
+ * One-shot stdin read bounded by a deadline. Resolves with the full stdin text,
+ * or rejects with a timeout Error if EOF never arrives. Callers decide fail-open
+ * behaviour (allow / silent-exit) in their catch block.
+ */
+export async function readStdinTextWithTimeout(
+  timeoutMs: number = STDIN_READ_TIMEOUT_MS,
+): Promise<string> {
+  return Promise.race([
+    Bun.stdin.text(),
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`stdin read timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      ).unref?.(),
+    ),
+  ]);
+}

--- a/plugins/itp-hooks/hooks/posttooluse-edit-time-orchestrator-aggregating-context-injecting-subhooks-into-single-bun-process-iter93-corrects-iter89-async-true-strict-dominance-claim.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-edit-time-orchestrator-aggregating-context-injecting-subhooks-into-single-bun-process-iter93-corrects-iter89-async-true-strict-dominance-claim.ts
@@ -300,7 +300,17 @@ async function runPostToolUseEditTimeOrchestratorMain(): Promise<void> {
   // in native code (no userspace TextDecoder cost), and the chunk-coalescing
   // bugs documented in Bun GitHub #7500 / #11553 / #3255 (for stdin.stream())
   // are bypassed entirely.
-  const inputText = await Bun.stdin.text();
+  // Guard the one-shot read: if the parent never closes stdin's write end
+  // (observed under heavy container load), Bun.stdin.text() blocks forever,
+  // leaking a bun process per tool call → memory pressure → SIGTRAP storms.
+  // Race against a hard deadline and silent-exit (orchestrator never blocks).
+  const stdinReadDeadlineMs = Number(process.env.ITP_HOOK_STDIN_TIMEOUT_MS) || 2000;
+  const inputText = await Promise.race([
+    Bun.stdin.text(),
+    new Promise<never>(() =>
+      setTimeout(() => process.exit(0), stdinReadDeadlineMs).unref?.()
+    ),
+  ]);
 
   let parsedInput: PostToolUseInput;
   try {

--- a/plugins/itp-hooks/hooks/posttooluse-glossary-sync.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-glossary-sync.ts
@@ -9,6 +9,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { join } from "node:path";
 import { $ } from "bun";
 import { trackHookError } from "./lib/hook-error-tracker.ts";
@@ -45,7 +46,7 @@ interface HookResult {
 
 async function parseStdin(): Promise<PostToolUseInput | null> {
   try {
-    const stdin = await Bun.stdin.text();
+    const stdin = await readStdinTextWithTimeout();
     if (!stdin.trim()) return null;
     return JSON.parse(stdin) as PostToolUseInput;
   } catch {

--- a/plugins/itp-hooks/hooks/posttooluse-pushover-budget-reminder.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-pushover-budget-reminder.ts
@@ -54,6 +54,7 @@
  */
 
 import { trackHookError } from "./lib/hook-error-tracker.ts";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { hasFileWideEscapeHatchMarkerInContent } from "./lib/shared-escape-hatch-marker-detection-helper-cross-pretooluse-and-posttooluse-iter107.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -200,8 +201,10 @@ function extractText(input: HookInput): string {
 
 async function main(): Promise<void> {
   let inputText = "";
-  for await (const chunk of Bun.stdin.stream()) {
-    inputText += new TextDecoder().decode(chunk);
+  try {
+    inputText = await readStdinTextWithTimeout();
+  } catch {
+    process.exit(0); // stdin read timed out → fail-open
   }
 
   let input: HookInput;

--- a/plugins/itp-hooks/hooks/posttooluse-readme-pypi-links.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-readme-pypi-links.ts
@@ -13,6 +13,7 @@
  */
 
 import { basename, dirname, resolve } from "node:path";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { trackHookError } from "./lib/hook-error-tracker.ts";
 
 // ============================================================================
@@ -42,7 +43,7 @@ interface HookResult {
 
 async function parseStdin(): Promise<PostToolUseInput | null> {
   try {
-    const stdin = await Bun.stdin.text();
+    const stdin = await readStdinTextWithTimeout();
     if (!stdin.trim()) return null;
     return JSON.parse(stdin) as PostToolUseInput;
   } catch (err) {

--- a/plugins/itp-hooks/hooks/posttooluse-reminder.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-reminder.ts
@@ -17,6 +17,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { join, basename } from "path";
 import { execSync } from "child_process";
 import { homedir } from "os";
@@ -648,8 +649,10 @@ function checkImplementationCode(
 async function main(): Promise<void> {
   // Read JSON from stdin
   let inputText = "";
-  for await (const chunk of Bun.stdin.stream()) {
-    inputText += new TextDecoder().decode(chunk);
+  try {
+    inputText = await readStdinTextWithTimeout();
+  } catch {
+    process.exit(0); // stdin read timed out → fail-open
   }
 
   let input: HookInput;

--- a/plugins/itp-hooks/hooks/posttooluse-terminology-sync.ts
+++ b/plugins/itp-hooks/hooks/posttooluse-terminology-sync.ts
@@ -15,6 +15,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { basename, dirname, join } from "node:path";
 import { Glob, $ } from "bun";
 import { trackHookError } from "./lib/hook-error-tracker.ts";
@@ -79,7 +80,7 @@ interface HookResult {
 
 async function parseStdin(): Promise<PostToolUseInput | null> {
   try {
-    const stdin = await Bun.stdin.text();
+    const stdin = await readStdinTextWithTimeout();
     if (!stdin.trim()) return null;
     return JSON.parse(stdin) as PostToolUseInput;
   } catch {

--- a/plugins/itp-hooks/hooks/pretooluse-helpers.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-helpers.ts
@@ -135,15 +135,42 @@ export function hasToolSchema(toolName: string): boolean {
 }
 
 /**
+ * Max time to wait for stdin EOF before failing open. Bun.stdin.text() blocks
+ * forever when the parent never closes the write end (observed under heavy
+ * container load: 9 PreToolUse guards per call all stuck in Sl sleep for ~59min,
+ * leaking ~31MB each → memory pressure → fresh bun spawns SIGTRAP/core-dump).
+ * Timing out and failing open keeps a slow/absent stdin from hanging the hook.
+ */
+const STDIN_READ_TIMEOUT_MS = Number(process.env.ITP_HOOK_STDIN_TIMEOUT_MS) || 2000;
+
+/**
  * Parse stdin JSON and return PreToolUseInput, or null if parsing fails.
- * On parse failure, automatically calls allow() and returns null (fail-open).
+ * On parse failure OR stdin-read timeout, automatically calls allow() and
+ * returns null (fail-open).
  */
 export async function parseStdinOrAllow(
   hookName: string
 ): Promise<PreToolUseInput | null> {
   const logger = createHookLogger(hookName);
   try {
-    const stdin = await Bun.stdin.text();
+    const stdin = await Promise.race([
+      Bun.stdin.text(),
+      new Promise<never>(() =>
+        setTimeout(() => {
+          // stdin EOF never arrived: emit fail-open decision and hard-exit.
+          // process.exit is required — the pending Bun.stdin.text() read is an
+          // active handle that keeps the event loop (and thus the bun process)
+          // alive until SIGTERM otherwise, which is the leak we're fixing.
+          logger.error("stdin read timed out — failing open", {
+            hook_event: "PreToolUse",
+            timeout_ms: STDIN_READ_TIMEOUT_MS,
+          });
+          trackHookError(hookName, `stdin read timed out after ${STDIN_READ_TIMEOUT_MS}ms`);
+          allow();
+          process.exit(0);
+        }, STDIN_READ_TIMEOUT_MS).unref?.()
+      ),
+    ]);
     const input = JSON.parse(stdin) as PreToolUseInput;
     logger.debug("Parsed stdin", {
       hook_event: "PreToolUse",

--- a/plugins/itp-hooks/hooks/pretooluse-iter78-layer3-stripped-path-edit-time-guard.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-iter78-layer3-stripped-path-edit-time-guard.ts
@@ -37,6 +37,7 @@
  */
 
 import { trackHookError } from "./lib/hook-error-tracker.ts";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 // Iter-107 migration: replace the hand-rolled escape-hatch detection
 // (regex + per-line preceding-window lookup loop) with the canonical
 // shared helper. Behavior-preserving — the iter-78 regex grammar
@@ -248,10 +249,12 @@ async function main(): Promise<void> {
   // Read raw stdin.
   let rawStdinText: string;
   try {
-    rawStdinText = await Bun.stdin.text();
+    rawStdinText = await readStdinTextWithTimeout();
   } catch {
+    // On stdin-read timeout the underlying read promise is still pending (an
+    // active handle that would keep bun alive). emitAllow() then hard-exit.
     emitAllow();
-    return;
+    process.exit(0);
   }
 
   // Pre-JSON-parse fastpath. If the raw stdin lacks the

--- a/plugins/itp-hooks/hooks/stop-orchestrator.ts
+++ b/plugins/itp-hooks/hooks/stop-orchestrator.ts
@@ -57,6 +57,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { readStdinTextWithTimeout } from "./lib/stdin-timeout.ts";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -172,12 +173,14 @@ function parseJSONOrEmpty(text: string): Record<string, unknown> {
 }
 
 async function main() {
-  // Pull stdin (Stop hook payload).
-  const payloadChunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    payloadChunks.push(Buffer.from(chunk));
+  // Pull stdin (Stop hook payload). Bounded read: a never-closed stdin must
+  // not hang the Stop hook forever (the leak that caused SIGTRAP storms).
+  let payload = "";
+  try {
+    payload = await readStdinTextWithTimeout();
+  } catch {
+    process.exit(0); // stdin read timed out → silent allow
   }
-  const payload = Buffer.concat(payloadChunks).toString("utf8");
 
   // stop_hook_active loop guard — Claude Code sets this to true on a
   // re-fire after a previous block decision. Aggregating block-reasons


### PR DESCRIPTION
## Problem
The PreToolUse guards + PostToolUse hooks read stdin via `await Bun.stdin.text()` / `Bun.stdin.stream()` with **no timeout**. When the parent process never closes stdin's write end (observed under heavy load), the read blocks **forever**.

Observed impact: a full fan-out of ~9 PreToolUse guards stuck in `Sl` sleep for ~59 min, ~31 MB each → memory pressure → fresh `bun` spawns crash with **SIGTRAP / core dump**, surfacing as `PostToolUse:Bash hook error … Trace/breakpoint trap (core dumped)`, and the container collapses (load 68 on 12 cores).

## Fix
- New shared `hooks/lib/stdin-timeout.ts` → `readStdinTextWithTimeout(ms=2000)` (tunable via `ITP_HOOK_STDIN_TIMEOUT_MS`), racing `Bun.stdin.text()` against a hard deadline.
- Wired into `parseStdinOrAllow`, both edit-time orchestrators, and the 7 direct stdin readers.
- Critical detail: on timeout the pending `Bun.stdin.text()` is an **active handle**, so `return` cannot terminate the process — each path emits a fail-open decision then `process.exit(0)`.

## Verification
- Never-closing stdin → hook self-exits ~2.0–2.2 s `rc=0` (was infinite / 8 s kill).
- Normal allow + deny (e.g. fork-bomb block) paths intact; all 10 files parse under `bun build`.

Fail-open is the correct posture for advisory hooks: a slow/absent stdin must never hang the tool call.