### PR TITLE
finalize: add Phase 0 to parse documented CLI flags

### DIFF
--- a/plugins/asciinema-tools/skills/finalize/SKILL.md
+++ b/plugins/asciinema-tools/skills/finalize/SKILL.md
@@ -33,6 +33,31 @@ Finalize orphaned asciinema recordings: stop running processes gracefully, compr
 
 ## Execution
 
+### Phase 0: Parse Arguments
+
+Parse `$ARGUMENTS` once at the top of the workflow so the later phases
+can consult `$FORCE`, `$ALL_MODE`, `$NO_PUSH`, and `$KEEP_LOCAL`.
+
+```bash
+/usr/bin/env bash << 'PARSE_EOF'
+FORCE=false
+ALL_MODE=false
+NO_PUSH=false
+KEEP_LOCAL=false
+TARGET_FILE=""
+for arg in $ARGUMENTS; do
+  case "$arg" in
+    --force)       FORCE=true ;;
+    --all)         ALL_MODE=true ;;
+    --no-push)     NO_PUSH=true ;;
+    --keep-local)  KEEP_LOCAL=true ;;
+    *)             TARGET_FILE="$arg" ;;
+  esac
+done
+export FORCE ALL_MODE NO_PUSH KEEP_LOCAL TARGET_FILE
+PARSE_EOF
+```
+
 ### Phase 1: Discovery
 
 ```bash


### PR DESCRIPTION
Fixes https://github.com/terrylica/cc-skills/issues/92.

The Arguments table advertised `--force`, `--all`, `--no-push`,
`--keep-local`, and Phase 3 already consulted `\$FORCE` for SIGKILL,
but no phase ever parsed `\$ARGUMENTS` to assign these variables. This
PR adds a `Phase 0: Parse Arguments` block that runs once at the top
of Execution and exports the four flags plus a `\$TARGET_FILE` slot,
so the existing `\$FORCE` check (and any future per-flag check) goes
live.