### PR TITLE
crucible-navigator: grant Edit/Write so the self-evolution step can apply its fix

### DIFF
--- a/plugins/crucible/skills/00-navigator/SKILL.md
+++ b/plugins/crucible/skills/00-navigator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: crucible-navigator
 description: starting a new research campaign, entering a new Claude Code session on a research repo, or when unsure which methodology.
-allowed-tools: Read, Glob, Grep
+allowed-tools: Read, Glob, Grep, Edit, Write
 ---
 
 # crucible-navigator — Research campaign orientation


### PR DESCRIPTION
Fixes https://github.com/terrylica/cc-skills/issues/94.

The frontmatter granted only Read/Glob/Grep, but the Self-Evolving
Skill block and the Post-Execution Reflection both instructed the
agent to "Edit this file in-place" and append to
`references/evolution-log.md`. Add Edit and Write to allowed-tools so
the self-evolution loop can actually persist the diagnosed fix.