### PR TITLE
fix(statusline): GIT_OPTIONAL_LOCKS=0 so renders never race user git commits

### DIFF
--- a/plugins/statusline-tools/statusline/custom-statusline.sh
+++ b/plugins/statusline-tools/statusline/custom-statusline.sh
@@ -21,6 +21,16 @@
 #   ~/asciinemalogs cast: <iterm2-uuid>
 #   The Cast UUID maps to: ~/Downloads/*.<iterm2-uuid>.*.cast
 
+# GIT_OPTIONAL_LOCKS=0 — the statusline must OBSERVE repo state, never CONTEND for it.
+# Every render runs `git status`/`git diff`, which by default take .git/index.lock to refresh
+# the index. Fired on each prompt render, that races a user's concurrent `git commit`/`git add`
+# in the same checkout (and in worktrees, the per-worktree index.lock), intermittently failing
+# their commit with "Unable to create '.../index.lock': File exists". Setting this env var (the
+# same mechanism VS Code and other IDEs use) makes all git subprocesses this script spawns skip
+# the OPTIONAL index lock — status/diff still report correctly, they just don't write index.lock.
+# Comprehensive + future-proof: covers every git call here, including any added later.
+export GIT_OPTIONAL_LOCKS=0
+
 # ANSI Color codes
 RESET='\033[0m'
 BRIGHT_BLACK='\033[90m'


### PR DESCRIPTION
## Problem
The statusline runs `git status` / `git diff` on every prompt render (M/D/S/U + ahead/behind).
By default those refresh the index under `.git/index.lock`. Fired on each render, this
intermittently **races a concurrent `git commit`/`git add`** in the same checkout — and, in git
worktrees, the per-worktree `index.lock` — failing the user's commit with:

```
fatal: Unable to create '.../index.lock': File exists.
Another git process seems to be running in this repository ...
```

Observed live: a multi-commit session in a sibling repo kept losing `git commit` to the statusline,
needing an atomic rm-lock+commit retry loop to land each commit.

## Fix
One line near the top of `custom-statusline.sh`:

```sh
export GIT_OPTIONAL_LOCKS=0
```

Every git subprocess the script spawns then **skips the OPTIONAL index lock** — status/diff still
report correctly, they just don't write `index.lock`. This is exactly the mechanism VS Code and
other IDEs use. Comprehensive (covers every git call, including any added later) and
observe-don't-contend by construction.

## Verification
- `bash -n` clean.
- Smoke render exits 0 with correct M/D/S/U counts (git status still works under the env var).