### PR TITLE
fix(tasks): name the failing scenario instead of asserting a cause

### DIFF
--- a/tasks/tests/test-iter180-meta-recursive-dogfood-of-iter177-bash5-epochrealtime-zero-fork-builtin-pattern-into-iter174-perf-baseline-harness-own-per-trial-timing-wrapper-eliminating-sixty-perl-forks-per-invocation.sh
+++ b/tasks/tests/test-iter180-meta-recursive-dogfood-of-iter177-bash5-epochrealtime-zero-fork-builtin-pattern-into-iter174-perf-baseline-harness-own-per-trial-timing-wrapper-eliminating-sixty-perl-forks-per-invocation.sh
@@ -35,6 +35,82 @@ iter180_assert_substring_present_in_dispatcher_with_human_readable_label() {
     fi
 }
 
+# ─── Failure-diagnosis helpers (observability only; no gate is relaxed) ──────
+#
+# WHY: E2 below compares TWO SEPARATE invocations of the iter-174 harness. When
+# a load-sensitive scenario gate fails in one invocation and not the other, the
+# assertion is correct to fire — but its message named MODE DISPATCH as the
+# cause, which the check never established. On 2026-09-03 four red suite runs
+# had to be triaged by hand for exactly that reason: the message asserted a
+# cause, and the evidence needed to disprove it was never printed.
+#
+# These helpers print WHICH clause failed and WHICH scenario failed, and emit a
+# stable machine-readable token so log triage reads a fact instead of inferring
+# one from prose. They are called ONLY from else-branches; every condition in
+# this file is byte-for-byte unchanged.
+
+# ── NEGATIVE CONTROL for this diagnostic (run before trusting it) ───────────
+#
+# BOTH halves are required. "Still fails" alone proves nothing was loosened but
+# not that the capture works; "names the cause" alone proves the capture works
+# but not that the gate still bites. Either half on its own is the shape of a
+# check that passes for the wrong reason.
+#
+#   HALF 1 — the gate still bites, and now says why.
+#     Temporarily pin an impossible cap on one scenario in the iter-174 harness
+#     (e.g. set the A5 backlog-proportional cap expression to 1), then:
+#         bash tasks/tests/test-iter180-...-sixty-perl-forks-per-invocation.sh
+#     EXPECT: E2 still reports ✗ (nothing was relaxed), AND the output now
+#     contains [HARNESS-SCENARIO-FAILURE] naming A5 with its median and cap.
+#     Revert the pin.
+#
+#   HALF 2 — a defect with NO scenario failure is positively distinguished.
+#     Temporarily make the harness echo the literal iter174_schema_version in
+#     human mode, leaving every scenario passing, then run the iter-182 sibling:
+#         bash tasks/tests/test-iter182-...-hyperfine-industry-gap.sh
+#     EXPECT: C1 reports ✗ with "clause 3 FAILED", AND the output contains
+#     [HARNESS-NO-SCENARIO-FAILURE] — proving a genuine leak is NOT reported as
+#     contention. Revert the echo.
+#
+#   Then re-run both unmodified and confirm each returns to a full PASS, so the
+#   controls are shown to be reversible rather than leaving a latent failure.
+
+# Print the harness's own failing scenario lines from a human-mode capture.
+iter180_name_failing_harness_scenarios_in_human_mode_capture() {
+    local harness_output_capture="$1"
+    local failing_scenario_lines
+    # `|| true`: grep exits 1 on no-match, and `set -e` would treat that as fatal.
+    failing_scenario_lines=$(printf '%s\n' "$harness_output_capture" | grep -E '^[[:space:]]*✗ A[0-9]+:' || true)
+    if [[ -z "$failing_scenario_lines" ]]; then
+        echo "      [HARNESS-NO-SCENARIO-FAILURE] human-mode: no '✗ A<n>' line — every scenario"
+        echo "        passed, so this is NOT a scenario regression and mode dispatch is a real suspect."
+        return 0
+    fi
+    echo "      [HARNESS-SCENARIO-FAILURE] human-mode: a scenario gate failed, so the mode"
+    echo "        disagreement is a SYMPTOM of that failure, not evidence of a dispatch regression:"
+    # `awk`, never `head`: `head` closes the pipe and kills `grep` with SIGPIPE,
+    # which `pipefail` promotes into a silent abort. The iter-182 sibling
+    # documents this exact trap in its own iter-186 fix comment.
+    printf '%s\n' "$failing_scenario_lines" | awk 'NR<=5 { print "        " $0 }'
+}
+
+# Same intent for a --json capture. Deliberately schema-light: the envelope's
+# per-scenario record shape is under active iter-186 edit, so this greps for the
+# verdict string rather than parsing fields that may be renamed tomorrow.
+iter180_name_failing_harness_scenarios_in_json_mode_capture() {
+    local harness_output_capture="$1"
+    local regress_lines
+    regress_lines=$(printf '%s\n' "$harness_output_capture" | grep -F 'REGRESS' || true)
+    if [[ -z "$regress_lines" ]]; then
+        echo "      [HARNESS-NO-SCENARIO-FAILURE] --json: no REGRESS verdict in the envelope —"
+        echo "        the envelope may be malformed or truncated rather than reporting a regression."
+        return 0
+    fi
+    echo "      [HARNESS-SCENARIO-FAILURE] --json: the envelope reports a regression; the"
+    echo "        per-scenario verdicts live in its results[] array:"
+    printf '%s\n' "$regress_lines" | awk 'NR<=5 { print "        " $0 }'
+}
+
 echo ""
 echo "═══════════════════════════════════════════════════════════════════════════════"
 echo "  ITER-180 META-RECURSIVE EPOCHREALTIME DOGFOOD REGRESSION TEST"
@@ -146,7 +222,28 @@ if [[ "$ITER180_HARNESS_HUMAN_MODE_OUTPUT_CAPTURE" == *"7/7 assertions PASSED"* 
    [[ "$ITER180_HARNESS_JSON_MODE_OUTPUT_CAPTURE" == *'"overall_verdict": "PASS"'* ]]; then
     echo "  ✓ E2: human-mode and --json mode yield consistent PASS verdict (no mode-divergence regression)"
 else
-    echo "  ✗ E2: human-mode + --json mode verdict inconsistency — mode dispatch may have regressed"
+    echo "  ✗ E2: human-mode + --json mode verdict inconsistency"
+    # Name the clause that actually failed. The previous single-line message
+    # asserted "mode dispatch may have regressed" for BOTH clauses, which is a
+    # cause this check never establishes — the two clauses read two separate
+    # harness invocations, and either can fail on its own.
+    if [[ "$ITER180_HARNESS_HUMAN_MODE_OUTPUT_CAPTURE" != *"7/7 assertions PASSED"* ]]; then
+        echo "      clause 1 FAILED: human-mode capture did not contain '7/7 assertions PASSED'"
+    fi
+    if [[ "$ITER180_HARNESS_JSON_MODE_OUTPUT_CAPTURE" != *'"overall_verdict": "PASS"'* ]]; then
+        echo "      clause 2 FAILED: --json capture did not contain overall_verdict PASS"
+    fi
+    # Both helpers run UNCONDITIONALLY, so exactly one token is emitted per
+    # invocation whichever clause failed. Calling them only inside the failing
+    # clause left a real hole: a defect that trips a clause WITHOUT any scenario
+    # failing would emit no token at all, and a log reader keying on the tokens
+    # would fall back to "probable contention" for what is a genuine defect —
+    # the precise misdiagnosis this whole change exists to remove.
+    iter180_name_failing_harness_scenarios_in_human_mode_capture "$ITER180_HARNESS_HUMAN_MODE_OUTPUT_CAPTURE"
+    iter180_name_failing_harness_scenarios_in_json_mode_capture "$ITER180_HARNESS_JSON_MODE_OUTPUT_CAPTURE"
+    echo "      NOTE: these are two SEPARATE invocations of the harness. A load-sensitive"
+    echo "        scenario gate failing in one and not the other produces this disagreement"
+    echo "        without any dispatch bug existing."
     ITER180_TOTAL_ASSERTIONS_FAILED=$((ITER180_TOTAL_ASSERTIONS_FAILED + 1))
 fi
 

--- a/tasks/tests/test-iter182-measurement-context-metadata-block-pytest-benchmark-machine-info-style-provenance-for-iter179-json-envelope-closing-criterion-rs-and-hyperfine-industry-gap.sh
+++ b/tasks/tests/test-iter182-measurement-context-metadata-block-pytest-benchmark-machine-info-style-provenance-for-iter179-json-envelope-closing-criterion-rs-and-hyperfine-industry-gap.sh
@@ -120,10 +120,17 @@ fi
 
 # B5: ordering — measurement_context appears AFTER trials_per_script and BEFORE results
 # (so AI agents reading top-to-bottom see context before raw data).
+#
+# ITER-186 SIGPIPE FIX: these three were `grep -nF … | head -1 | cut -d: -f1`.
+# Under this file's `set -euo pipefail`, `head -1` closes the pipe on `grep`,
+# which then dies of SIGPIPE with 141; `pipefail` promotes it and `set -e`
+# aborts the test with no diagnostic. Unlike the failure-branch `head -3`
+# diagnostics elsewhere in this file, these run on EVERY invocation, so the race
+# was live on every suite run. `awk` drains its input and cannot signal `grep`.
 ITER182_TOTAL_ASSERTIONS_EVALUATED=$((ITER182_TOTAL_ASSERTIONS_EVALUATED + 1))
-ITER182_LINE_OF_TRIALS_PER_SCRIPT=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"trials_per_script"' | head -1 | cut -d: -f1)
-ITER182_LINE_OF_MEASUREMENT_CONTEXT=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"iter182_measurement_context' | head -1 | cut -d: -f1)
-ITER182_LINE_OF_RESULTS_ARRAY=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"results"' | head -1 | cut -d: -f1)
+ITER182_LINE_OF_TRIALS_PER_SCRIPT=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"trials_per_script"' | awk -F: 'NR==1{print $1}')
+ITER182_LINE_OF_MEASUREMENT_CONTEXT=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"iter182_measurement_context' | awk -F: 'NR==1{print $1}')
+ITER182_LINE_OF_RESULTS_ARRAY=$(echo "$ITER182_JSON_ENVELOPE_OUTPUT_CAPTURE" | grep -nF '"results"' | awk -F: 'NR==1{print $1}')
 if [[ -n "$ITER182_LINE_OF_TRIALS_PER_SCRIPT" ]] && [[ -n "$ITER182_LINE_OF_MEASUREMENT_CONTEXT" ]] && [[ -n "$ITER182_LINE_OF_RESULTS_ARRAY" ]] && \
    (( ITER182_LINE_OF_TRIALS_PER_SCRIPT < ITER182_LINE_OF_MEASUREMENT_CONTEXT )) && \
    (( ITER182_LINE_OF_MEASUREMENT_CONTEXT < ITER182_LINE_OF_RESULTS_ARRAY )); then
@@ -137,6 +144,29 @@ fi
 echo ""
 echo "GROUP C (1 assertion): human-mode invocation still 7/7 PASS (regression-safe; iter-182 metadata only emitted in --json mode)"
 
+# Failure-diagnosis helper (observability only; the C1 condition below is
+# byte-for-byte unchanged). C1 is a THREE-clause conjunction, and its single
+# failure message named only two of the three possibilities — "regressed OR
+# leaked measurement_context" — so a run that failed on the 7/7 clause because
+# a load-sensitive scenario gate tripped reported a JSON-leak suspicion instead
+# of the scenario that actually failed. Observed on 2026-09-03.
+iter182_name_failing_harness_scenarios_in_human_mode_capture() {
+    local harness_output_capture="$1"
+    local failing_scenario_lines
+    # `|| true`: grep exits 1 on no-match, which `set -e` would treat as fatal.
+    failing_scenario_lines=$(printf '%s\n' "$harness_output_capture" | grep -E '^[[:space:]]*✗ A[0-9]+:' || true)
+    if [[ -z "$failing_scenario_lines" ]]; then
+        echo "      [HARNESS-NO-SCENARIO-FAILURE] no '✗ A<n>' scenario line in the capture —"
+        echo "        the 7/7 clause did not fail because of a scenario gate."
+        return 0
+    fi
+    echo "      [HARNESS-SCENARIO-FAILURE] a scenario gate failed in this invocation:"
+    # `awk`, never `head` — `head` closes the pipe and kills `grep` with SIGPIPE,
+    # which `pipefail` promotes into a silent abort. Same trap this file's own
+    # iter-186 B5 fix documents above.
+    printf '%s\n' "$failing_scenario_lines" | awk 'NR<=5 { print "        " $0 }'
+}
+
 ITER182_HUMAN_MODE_OUTPUT_CAPTURE=$(bash "$ITER182_ITER174_HARNESS_ABSOLUTE_PATH" 2>&1 || true)
 
 ITER182_TOTAL_ASSERTIONS_EVALUATED=$((ITER182_TOTAL_ASSERTIONS_EVALUATED + 1))
@@ -145,7 +175,22 @@ if [[ "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" == *"7/7 assertions PASSED"* ]] && \
    [[ "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" != *"iter174_schema_version"* ]]; then
     echo "  ✓ C1: human-mode still 7/7 PASS + no JSON-envelope leak (measurement_context only emitted in --json mode)"
 else
-    echo "  ✗ C1: human-mode regressed OR leaked measurement_context block into text output"
+    echo "  ✗ C1: human-mode 7/7-PASS + no-JSON-leak invariant violated"
+    # Name the clause that actually failed, rather than asserting a cause.
+    if [[ "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" != *"7/7 assertions PASSED"* ]]; then
+        echo "      clause 1 FAILED: capture did not contain '7/7 assertions PASSED'"
+    fi
+    if [[ "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" == *"iter182_measurement_context"* ]]; then
+        echo "      clause 2 FAILED: measurement_context block LEAKED into human-mode text output"
+    fi
+    if [[ "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" == *"iter174_schema_version"* ]]; then
+        echo "      clause 3 FAILED: iter174_schema_version LEAKED into human-mode text output"
+    fi
+    # Unconditional, so a token is always emitted whichever clause failed. A
+    # pure JSON leak (clauses 2/3) with every scenario passing must be
+    # positively distinguishable from a scenario failure — otherwise a genuine
+    # leak reads as "probably contention" and gets waved through on a re-run.
+    iter182_name_failing_harness_scenarios_in_human_mode_capture "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE"
     echo "      (tail: $(echo "$ITER182_HUMAN_MODE_OUTPUT_CAPTURE" | tail -3))"
     ITER182_TOTAL_ASSERTIONS_FAILED=$((ITER182_TOTAL_ASSERTIONS_FAILED + 1))
 fi

--- a/tasks/triage-hook-regression-suite-log-classifying-known-flake-mechanisms-wall-clock-scenario-gate-versus-subprocess-exit-code-verdict-with-unknown-bucket-for-unrecognised-failures.sh
+++ b/tasks/triage-hook-regression-suite-log-classifying-known-flake-mechanisms-wall-clock-scenario-gate-versus-subprocess-exit-code-verdict-with-unknown-bucket-for-unrecognised-failures.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+#MISE description="Triage a repo:test-hooks suite log into the known intermittent-failure mechanisms so a red run is diagnosed from evidence instead of re-run until green. Reads a captured suite log (moon run repo:test-hooks > log 2>&1) and classifies each failing assertion as CLASS A (a wall-clock scenario gate exceeded its cap — load-sensitive), CLASS A? (two harness invocations disagreed and the failing scenario is UNNAMED, so the reduction to CLASS A is INFERRED, not observed), CLASS B (the iter-160 doctor ran and reported a non-healthy verdict — a CRITICAL check returned non-zero, which is fork/exec pressure rather than elapsed time), CLASS C (a genuine mode-dispatch or JSON-leak defect, positively distinguished from CLASS A by the harness reporting that NO scenario failed), or UNKNOWN (matches no known mechanism — deliberately never absorbed into the nearest bucket, so a third mechanism has to announce itself). Prints the margin on every wall-clock failure because a 0.9%-over run and a 300%-over run are different diagnoses and must never render identically."
+#
+# ═══════════════════════════════════════════════════════════════════════════
+#  Provenance
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Built 2026-09-03 from three real red runs captured at 18:08-18:10 while five
+# concurrent full suites plus a 36-process doctor repro were running on the same
+# box. Six consecutive green runs immediately beforehand, with the identical
+# command and the identical tree, are why "re-run it" was never going to find
+# this: the variable was another process tree, invisible from inside either one.
+#
+# The classes are empirical, not designed. Each one is a failure shape that was
+# actually observed and hand-triaged; the UNKNOWN bucket exists because that
+# hand-triage twice found a shape the previous pass had not predicted.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+#  Two corrections found by READING the harness, not by running it
+# ═══════════════════════════════════════════════════════════════════════════
+#
+#  1. The wall-clock pattern MUST be anchored to the `✗` form. The harness has a
+#     CC_SKILLS_SKIP_PERF_TIMING path that emits a PASSING line still containing
+#     the literal "median=NNNms > cap=NNNms". An unanchored substring match reads
+#     that success as a CLASS A failure — a classifier that invents a red run.
+#
+#  2. `median=...` alone cannot be trusted to mean "a gate failed", for the same
+#     reason. Every match below requires the failure marker on the same line.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+#  Usage
+# ═══════════════════════════════════════════════════════════════════════════
+#
+#   moon run repo:test-hooks > /tmp/suite.log 2>&1 || true
+#   bash tasks/triage-hook-regression-suite-log-...-unrecognised-failures.sh /tmp/suite.log
+#
+# Exits 0 always: this is a diagnostic, not a gate. A triage tool that can fail
+# gives you two problems to debug instead of one.
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    printf 'usage: %s <suite.log> [more.log ...]\n' "$0" >&2
+    printf '       %s --self-test\n' "$0" >&2
+    printf '\n  Capture one with:  moon run repo:test-hooks > /tmp/suite.log 2>&1 || true\n' >&2
+    exit 2
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  --self-test: negative-control the instrument against synthetic fixtures
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Nobody negative-controls the instrument, which is why the instrument is
+# likelier to be wrong than the thing it measures. Five separate diagnostic
+# defects on 2026-09-03 were each caught by another pair of eyes or by a
+# deliberately-broken input — never by re-reading the code that had the bug.
+#
+# The FIRST fixture is the one that matters most: a PASSING skip-path line that
+# still contains the literal "median=NNNms > cap=NNNms". An unanchored CLASS A
+# matcher classifies that success as a wall-clock failure and prints a confident
+# margin for a test that passed. This asserts it lands in GREEN.
+#
+# Deliberately NOT placed in tasks/tests/: that directory is auto-discovered and
+# executed by the suite, and shipping an unverified test there would redden
+# everyone else's runs — the exact half-written-edit failure this repo hit twice
+# today. Run it by hand; promote it once it has passed.
+#
+# NOTE: no heredocs anywhere in this file, by choice. cc-skills#113 is an
+# unterminated heredoc that makes the runner discover 113 tests, run zero, and
+# exit 0. printf with explicit newlines cannot fail that way.
+if [[ "${1:-}" == "--self-test" ]]; then
+    triage_self_test_directory=$(mktemp -d)
+    trap 'rm -rf "$triage_self_test_directory"' EXIT
+    triage_self_test_failure_count=0
+
+    triage_assert_fixture_classifies_as() {
+        local fixture_name="$1"
+        local expected_marker="$2"
+        local fixture_body="$3"
+        local fixture_path="$triage_self_test_directory/$fixture_name.log"
+        printf '%s\n' "$fixture_body" > "$fixture_path"
+        local actual_output
+        # `bash "$0"`, not `"$0"`: this file carries no executable bit (matching
+        # every other tasks/*.sh, which the suite invokes as `bash <path>`), so
+        # direct invocation dies with "Permission denied" before classification
+        # is ever reached. Found by running the self-test — all eight fixtures
+        # reported MISCLASSIFIED for a reason that had nothing to do with
+        # classification, which is precisely the false signal a self-test is
+        # supposed to catch rather than emit.
+        actual_output=$(bash "$0" "$fixture_path" 2>&1 || true)
+        # NO PIPE. `printf … | grep -q` is a SIGPIPE race under `pipefail`: the
+        # early-exiting reader kills the producer, the pipeline inherits 141,
+        # and in an `if` condition the boolean INVERTS — grep finds the marker
+        # and the test reports failure anyway. A self-test that lies about
+        # itself is worse than no self-test. The captured text is already in a
+        # variable; matching it directly removes the reader and the race.
+        if [[ "$actual_output" == *"$expected_marker"* ]]; then
+            printf '  ✓ %-34s → %s\n' "$fixture_name" "$expected_marker"
+        else
+            printf '  ✗ %-34s → expected %s, got:\n' "$fixture_name" "$expected_marker"
+            printf '%s\n' "$actual_output" | awk '{ print "      " $0 }'
+            triage_self_test_failure_count=$((triage_self_test_failure_count + 1))
+        fi
+    }
+
+    printf '\nSELF-TEST — classifier against synthetic fixtures\n\n'
+
+    # THE load-bearing one. A passing skip-path line carrying the scary string.
+    triage_assert_fixture_classifies_as "skip-path-passing-line" "GREEN" \
+'  ✓ A5: iter-165 pending-release aggregator: median=308ms > cap=305ms — perf timing NOT gated (CC_SKILLS_SKIP_PERF_TIMING)
+  ✓ FILE-PASS: test-iter174-harness'
+
+    triage_assert_fixture_classifies_as "genuine-wall-clock-failure" "CLASS A — WALL-CLOCK" \
+'  ✗ A5: iter-165 pending-release aggregator (backlog=5 commits): median=308ms > cap=305ms (REGRESSION: 1% over cap)
+  ✗ FILE-FAIL: test-iter174-harness
+  ✓ FILE-PASS: test-something-else'
+
+    triage_assert_fixture_classifies_as "vacuous-suite-ran-nothing" "VACUOUS" \
+'→ Discovered 113 test file(s)
+tasks/test-marketplace-hook-regression-suite: line 386: warning: here-document at line 257 delimited by end-of-file'
+
+    triage_assert_fixture_classifies_as "doctor-verdict-degraded" "CLASS B" \
+'  ✓ D1: --json summary critical_passed≥10 (total 13)
+  ✗ D2: --json summary verdict still TOOLKIT_HEALTHY after iter-163 extension (substring missing)
+  ✗ FILE-FAIL: test-iter163-status-doctor
+  ✓ FILE-PASS: test-something-else'
+
+    triage_assert_fixture_classifies_as "disagreement-scenario-named" "CLASS A (CONFIRMED)" \
+'  ✗ E2: human-mode + --json mode verdict inconsistency
+      [HARNESS-SCENARIO-FAILURE] --json: the envelope reports a regression
+  ✗ FILE-FAIL: test-iter180-dogfood
+  ✓ FILE-PASS: test-something-else'
+
+    triage_assert_fixture_classifies_as "disagreement-genuine-defect" "CLASS C" \
+'  ✗ C1: human-mode 7/7-PASS + no-JSON-leak invariant violated
+      clause 3 FAILED: iter174_schema_version LEAKED into human-mode text output
+      [HARNESS-NO-SCENARIO-FAILURE] no scenario line in the capture
+  ✗ FILE-FAIL: test-iter182-measurement-context
+  ✓ FILE-PASS: test-something-else'
+
+    triage_assert_fixture_classifies_as "disagreement-old-log-no-token" "CLASS A?" \
+'  ✗ E2: human-mode + --json mode verdict inconsistency — mode dispatch may have regressed
+  ✗ FILE-FAIL: test-iter180-dogfood
+  ✓ FILE-PASS: test-something-else'
+
+    triage_assert_fixture_classifies_as "unrecognised-assertion" "UNKNOWN" \
+'  ✗ Z9: an assertion nobody has classified yet
+  ✗ FILE-FAIL: test-brand-new-thing
+  ✓ FILE-PASS: test-something-else'
+
+    printf '\n'
+    if (( triage_self_test_failure_count == 0 )); then
+        printf 'SELF-TEST: all fixtures classified correctly\n\n'
+        exit 0
+    fi
+    printf 'SELF-TEST: %s fixture(s) MISCLASSIFIED\n\n' "$triage_self_test_failure_count"
+    exit 1
+fi
+
+# A line reporting a wall-clock cap breach. The `✗` is load-bearing — see
+# correction 1 in the header. Kept in one variable so the UNKNOWN filter below
+# cannot drift out of sync with the CLASS A matcher above it.
+TRIAGE_WALL_CLOCK_FAILURE_PATTERN='✗ .*median=[0-9]+ms > cap=[0-9]+ms'
+
+# Covers the pre-2026-09-03 message text AND the replacement that names the
+# failing clause, because old captured logs outlive the code that wrote them.
+TRIAGE_INVOCATION_DISAGREEMENT_PATTERN='✗ (E2|C1):.*(verdict inconsistency|human-mode regressed|invariant violated)'
+
+TRIAGE_DOCTOR_VERDICT_FAILURE_PATTERN='✗ D2:.*verdict still TOOLKIT_HEALTHY'
+
+for triage_each_log_path in "$@"; do
+    if [[ ! -r "$triage_each_log_path" ]]; then
+        printf '\n=== %s\n  UNREADABLE — no such file, or not readable\n' "$triage_each_log_path"
+        continue
+    fi
+
+    printf '\n=== %s\n' "$triage_each_log_path"
+
+    triage_failing_file_count=$(grep -cE '^  ✗ FILE-FAIL:' "$triage_each_log_path" || true)
+    triage_passing_file_count=$(grep -cE '✓ FILE-PASS:' "$triage_each_log_path" || true)
+    triage_executed_file_count=$(( triage_failing_file_count + triage_passing_file_count ))
+
+    # ── VACUOUS: the suite discovered tests and then ran none of them ────────
+    #
+    # cc-skills#113: an unterminated heredoc in the runner is a bash WARNING,
+    # which `set -euo pipefail` does not catch. The suite prints "Discovered 113
+    # test file(s)", executes ZERO, and exits 0. It fires on a DIRTY tree —
+    # precisely when someone is mid-edit and most wants the gate.
+    #
+    # Absence of failures is NOT evidence of success, and this branch exists
+    # because the first version of THIS FILE made exactly that mistake: it
+    # keyed GREEN off "no FILE-FAIL lines", which a run of zero tests satisfies
+    # perfectly. A triage tool that certifies a vacuous suite as green is worse
+    # than no triage tool, because it converts a loud failure into a quiet one.
+    triage_discovered_file_count=$(
+        grep -oE 'Discovered [0-9]+ test file' "$triage_each_log_path" |
+            awk 'NR==1 { print $2 }' || true
+    )
+    if (( triage_executed_file_count == 0 )); then
+        # The discovered count is OMITTED when the log does not carry it —
+        # absent is a state, not a value to invent a word for.
+        if [[ -n "$triage_discovered_file_count" ]]; then
+            printf '  ⛔ VACUOUS — discovered %s test file(s), EXECUTED ZERO.\n' \
+                "$triage_discovered_file_count"
+        else
+            printf '  ⛔ VACUOUS — EXECUTED ZERO test files.\n'
+        fi
+        printf '     This log proves NOTHING. Exit 0 here is not a pass (see cc-skills#113:\n'
+        printf '     an unterminated heredoc in the runner warns, runs nothing, and exits 0).\n'
+        printf '     Check first:  grep -n "here-document" <this log>\n'
+        continue
+    fi
+
+    if [[ -n "$triage_discovered_file_count" ]] && (( triage_executed_file_count < triage_discovered_file_count )); then
+        printf '  ⚠ PARTIAL — discovered %s test file(s) but only %s executed.\n' \
+            "$triage_discovered_file_count" "$triage_executed_file_count"
+        printf '     The run aborted early; anything not listed below was never checked.\n'
+    fi
+
+    if (( triage_failing_file_count == 0 )); then
+        printf '  GREEN — %s test file(s) executed, none failed\n' "$triage_executed_file_count"
+        continue
+    fi
+    printf '  %s failing test file(s), %s executed\n' \
+        "$triage_failing_file_count" "$triage_executed_file_count"
+
+    # ── CLASS A: a wall-clock gate exceeded its cap ──────────────────────────
+    if grep -qE "$TRIAGE_WALL_CLOCK_FAILURE_PATTERN" "$triage_each_log_path"; then
+        printf '\n  CLASS A — WALL-CLOCK SCENARIO GATE (load-sensitive)\n'
+        grep -oE '✗ A[0-9]+:.*' "$triage_each_log_path" | awk 'NR<=5 { print "    " $0 }' || true
+
+        # The margin IS the diagnosis. Per-mille then split, because integer
+        # division renders a 3ms overshoot on a 305ms cap as "0%" — hiding the
+        # single number that separates ambient contention from a real
+        # regression. A sub-1% margin is contention; 300% is a broken script.
+        #
+        # Two-stage and ANCHORED. Extracting `median=… > cap=…` directly from
+        # the file would re-admit the passing CC_SKILLS_SKIP_PERF_TIMING line
+        # that correction 1 exists to exclude, and print a margin for a scenario
+        # that PASSED — the same defect one layer down, which is exactly how a
+        # diagnostic starts lying. Stage one keeps only failure lines; stage two
+        # reads the numbers out of them.
+        triage_margin_pairs_from_failure_lines=$(
+            grep -oE "$TRIAGE_WALL_CLOCK_FAILURE_PATTERN" "$triage_each_log_path" |
+                grep -oE 'median=[0-9]+ms > cap=[0-9]+ms' || true
+        )
+        printf '%s\n' "$triage_margin_pairs_from_failure_lines" | while read -r triage_each_margin_pair; do
+            [[ -z "$triage_each_margin_pair" ]] && continue
+            triage_observed_median_ms=${triage_each_margin_pair#median=}
+            triage_observed_median_ms=${triage_observed_median_ms%%ms*}
+            triage_pinned_cap_ms=${triage_each_margin_pair##*cap=}
+            triage_pinned_cap_ms=${triage_pinned_cap_ms%ms}
+            if (( triage_pinned_cap_ms > 0 )); then
+                triage_margin_per_mille=$(( (triage_observed_median_ms - triage_pinned_cap_ms) * 1000 / triage_pinned_cap_ms ))
+                printf '    margin: %sms over %sms cap (%s.%s%% over)\n' \
+                    "$(( triage_observed_median_ms - triage_pinned_cap_ms ))" \
+                    "$triage_pinned_cap_ms" \
+                    "$(( triage_margin_per_mille / 10 ))" \
+                    "$(( triage_margin_per_mille % 10 ))"
+            fi
+        done
+    fi
+
+    # ── CLASS A? / CLASS C: two harness invocations disagreed ────────────────
+    #
+    # Whether this is CLASS A depends on evidence the test now emits. When the
+    # harness reported a failing scenario, the reduction is OBSERVED. When it
+    # reported that no scenario failed, this is a genuine dispatch/leak defect
+    # and belongs in its own class. When neither token is present the log
+    # predates that diagnostic, and the reduction stays explicitly INFERRED.
+    if grep -qE "$TRIAGE_INVOCATION_DISAGREEMENT_PATTERN" "$triage_each_log_path"; then
+        if grep -qF '[HARNESS-SCENARIO-FAILURE]' "$triage_each_log_path"; then
+            printf '\n  CLASS A (CONFIRMED) — invocation disagreement caused by a named scenario failure\n'
+            grep -A2 -F '[HARNESS-SCENARIO-FAILURE]' "$triage_each_log_path" | awk 'NR<=8 { print "    " $0 }' || true
+        elif grep -qF '[HARNESS-NO-SCENARIO-FAILURE]' "$triage_each_log_path"; then
+            printf '\n  CLASS C — GENUINE MODE-DISPATCH / JSON-LEAK DEFECT\n'
+            printf '    The harness reported that NO scenario failed, so this is NOT contention.\n'
+            printf '    This is the real defect the old message used to claim without evidence.\n'
+            grep -oE '✗ (E2|C1):.*' "$triage_each_log_path" | awk 'NR<=4 { print "    " $0 }' || true
+        else
+            printf '\n  CLASS A? — HARNESS INVOCATIONS DISAGREE (reduction to CLASS A is INFERRED)\n'
+            grep -oE '✗ (E2|C1):.*' "$triage_each_log_path" | awk 'NR<=4 { print "    " $0 }' || true
+            printf '    NOTE: this log predates the clause-naming diagnostic, so the failing\n'
+            printf '          scenario is unnamed. Do NOT record this as a confirmed CLASS A.\n'
+        fi
+    fi
+
+    # ── CLASS B: the doctor ran and reported a non-healthy verdict ───────────
+    if grep -qE "$TRIAGE_DOCTOR_VERDICT_FAILURE_PATTERN" "$triage_each_log_path"; then
+        printf '\n  CLASS B — VERDICT / SUBPROCESS EXIT CODE\n'
+        if grep -qE '✓ D1:.*critical_passed' "$triage_each_log_path"; then
+            printf '    ✓ D1 passed alongside ✗ D2 — critical_passed in [10,13] of 13, so between\n'
+            printf '      1 and 3 CRITICAL checks returned non-zero.\n'
+        else
+            printf '    ⚠ D1 did NOT pass — the bound is wider than the 1-3 observed on 2026-09-03.\n'
+        fi
+        for triage_each_group_letter in A B C E; do
+            if grep -qE "✗ ${triage_each_group_letter}[0-9]+:" "$triage_each_log_path"; then
+                printf '    ⚠ group %s also failed — the doctor may NOT have run cleanly.\n' "$triage_each_group_letter"
+            fi
+        done
+        printf '    (A/B/C/E all green ⇒ the doctor ran and emitted parseable JSON: not a crash,\n'
+        printf '     not a spawn failure. Every one of its 15 verdicts is a subprocess exit code.)\n'
+    fi
+
+    # ── UNKNOWN: never absorbed into the nearest bucket ──────────────────────
+    #
+    # This is the anti-vacuous-gate property and the easiest one to lose in a
+    # cleanup. If a future edit makes this branch unreachable, the tool starts
+    # silently reporting every novel failure as one of the shapes it already
+    # knows, which is worse than having no tool at all.
+    triage_unclassified_assertions=$(
+        grep -oE '✗ [A-Z][0-9]+:.*' "$triage_each_log_path" |
+            grep -vE "$TRIAGE_WALL_CLOCK_FAILURE_PATTERN" |
+            grep -vE "$TRIAGE_INVOCATION_DISAGREEMENT_PATTERN" |
+            grep -vE "$TRIAGE_DOCTOR_VERDICT_FAILURE_PATTERN" || true
+    )
+    if [[ -n "$triage_unclassified_assertions" ]]; then
+        printf '\n  UNKNOWN — matches no known mechanism; investigate rather than assume:\n'
+        printf '%s\n' "$triage_unclassified_assertions" | awk 'NR<=10 { print "    " $0 }'
+    fi
+done


### PR DESCRIPTION
Refs #106, #113. Completes the diagnostic-honesty work started in #115.

## The defect

`E2` (iter-180) and `C1` (iter-182) compare two **separate invocations** of the iter-174 harness. When a load-sensitive scenario gate fails in one and not the other, both assertions are correct to fire — but their messages named `"mode dispatch may have regressed"` and `"human-mode regressed OR leaked measurement_context"`, causes **neither check ever established**. Four red suite runs on 2026-09-03 had to be triaged by hand for exactly that reason.

Same family as #114: a check whose failure branch asserts a pre-written cause produces output that is identical whether or not it learned anything.

**Observability only.** Every `if` condition in both tests is byte-for-byte unchanged — only `else` branches were expanded and helpers added.

## What the messages say now

E2 and C1 name the failing **clause** and emit a stable token: `[HARNESS-SCENARIO-FAILURE]` carrying the offending `✗ A<n>` line, or `[HARNESS-NO-SCENARIO-FAILURE]`. That distinction is the point — it separates "a flaky scenario gate tripped this" from "a genuine dispatch or leak defect", which the old message could not do in either direction.

## Negative control: both halves, real output

**HALF 1 — the gate still bites, and now says why.** A5's cap pinned to 1 ms in an isolated mirror:

```
✗ E2: human-mode + --json mode verdict inconsistency
    clause 1 FAILED: human-mode capture did not contain '7/7 assertions PASSED'
    clause 2 FAILED: --json capture did not contain overall_verdict PASS
    [HARNESS-SCENARIO-FAILURE] human-mode: a scenario gate failed …
        ✗ A5: … median=176ms > cap=1ms (REGRESSION: 17500% over cap)
    [HARNESS-SCENARIO-FAILURE] --json: …
        {"id": "A5", …, "cap_ms": 1, "verdict": "REGRESS"}
✗ ITER-180 REGRESSION TEST: 13/15 assertions passed, 2 FAILED   (exit 1)
```

Still fails, same boundary, and names A5 in both invocations.

**HALF 2 — a genuine defect is positively distinguished.** The harness is made to leak `iter174_schema_version` into human-mode output while every scenario passes:

```
✗ C1: human-mode 7/7-PASS + no-JSON-leak invariant violated
    clause 3 FAILED: iter174_schema_version LEAKED into human-mode text output
    [HARNESS-NO-SCENARIO-FAILURE] no '✗ A<n>' scenario line in the capture —
      the 7/7 clause did not fail because of a scenario gate.
    (tail: … ✓ ITER-174 …: 7/7 assertions PASSED)               (exit 1)
```

Clause 3, not clause 1, and `NO-SCENARIO-FAILURE` — so a real leak routes to CLASS C instead of being written off as contention.

**Reverted and clean:** iter-180 **15/15 exit 0**, iter-182 **15/15 exit 0**.

## Three failures during verification, all reported rather than buried

**The apparatus failed its own control first.** The unmodified mirror reported 4 failed assertions — because `find scripts -maxdepth 1 … -type f` does not match a symlink (type `l`), so every benchmark subject resolved EMPTY and the harness fail-fasted. Without that step, an apparatus artifact would have been read as a diagnostic result. Fixed with hard links; the unmodified mirror then gave 15/15, exit 0.

**HALF 2's first attempt did not test what was intended.** The *real* A5 flake fired mid-run at `median=348ms > cap=347ms` (0.3% over), the harness took its failure branch, and the injected leak — placed only in the all-passed branch — never executed. Corrected by injecting before both branches and raising A5's cap so the flake cannot decide the experiment. That is confounder control, not gate-softening: HALF 1 is where that same gate is made *stricter*.

**The classifier self-test's first run failed all eight on `Permission denied`** — `"$0"` invoked on a file without an executable bit. Classification was never reached, and the self-test correctly refused to report a pass. A self-test that fails closed is the entire reason to have one.

## The classifier, promoted out of `/tmp`

`tasks/triage-hook-regression-suite-log-…` classifies a suite log into known flake mechanisms. **Self-test: 8/8**, including a deliberately load-bearing fixture — a *passing* skip-path line that still contains the literal text `median=308ms > cap=305ms`, asserted to land in GREEN. (The harness's `CC_SKILLS_SKIP_PERF_TIMING` path emits success text carrying a failure-shaped substring; an unanchored matcher reads it as a wall-clock failure and prints a confident margin for a test that passed.)

Design properties, each load-bearing:

- **prints the margin** — `0.9%` and `300%` must never render identically; that distinction *is* the diagnosis
- **`CLASS A?` when inferred**, upgrading to `CLASS A (CONFIRMED)` only when a token proves it, so a hypothesis is never read as a finding
- **UNKNOWN** for anything matching no known mechanism, rather than the nearest bucket — a third mechanism has to announce itself
- **⛔ VACUOUS / ⚠ PARTIAL / GREEN-with-execution-count** — added after #113 exposed that the original GREEN rule was `failing_file_count == 0`, which a run executing **zero** tests satisfies perfectly. The anti-vacuous property had been guarding the failure path and leaving the success path open.

Two deliberate placements: **not** in `tasks/tests/` (auto-discovered, and would run as a test), and **no heredocs anywhere in it**, because #113 *is* an unterminated heredoc that makes the runner discover 113 tests, run zero, and exit 0. Both are comments in the file.

**Stated limitation:** given a single-test log rather than a suite log, the classifier reports VACUOUS, since such logs carry no `FILE-PASS`/`FILE-FAIL` lines. Defensible, but worth knowing before pointing it at the wrong artifact.

## Incidental: the A5 cap formula, derived from source

`200 + 21 × backlog` — which computes to 347 at the backlog=7 observed during this control run, and to exactly the 305 measured independently at backlog=5. The formula is confirmed from the source rather than fitted to a measurement, which retires the last loose end of the A5 investigation. Recording it as a formula and not as `305` is deliberate: quoting the value sends the next investigator after a phantom second bug.

## Authorship note

The `test-iter182` hunk labelled **ITER-186 SIGPIPE FIX** — three B5 line lookups moving from `grep | head -1 | cut` to `grep | awk` — is **not the author's work**. It is another agent's uncommitted iter-186 change, already present in the working tree, interleaved in the same file. Partial staging is interactive-only in this environment, so it rides along here, attributed rather than claimed. Flagged because a PR that silently carries another agent's uncommitted work is how authorship quietly goes wrong.

`moon.yml` is deliberately untouched; registering the classifier as a task is a one-line follow-up, held back to avoid a concurrent-edit collision.
