### PR TITLE
fix(perf-baseline): say a fork failure is not a timing failure

### DIFF
--- a/tasks/tests/test-iter174-empirical-wall-clock-perf-baseline-regression-harness-for-conventional-commits-toolkit-pinning-current-median-latencies-of-iter150-iter152-iter153-iter165-with-regression-detection-against-three-x-headroom-cap.sh
+++ b/tasks/tests/test-iter174-empirical-wall-clock-perf-baseline-regression-harness-for-conventional-commits-toolkit-pinning-current-median-latencies-of-iter150-iter152-iter153-iter165-with-regression-detection-against-three-x-headroom-cap.sh
@@ -523,7 +523,15 @@ iter174_run_single_benchmark_scenario_measuring_median_and_comparing_to_pinned_b
             iter179_emit_text_only_in_human_readable_mode_suppress_in_json_mode_to_keep_stdout_parse_clean "  ✓ ${human_readable_scenario_label}: forks=${iter186_observed_external_fork_count} ≤ ceiling ${iter186_pinned_fork_count_gating_this_scenario}${iter186_perl_fragment_for_verdict_line} (load-invariant gate; wall clock ${observed_median_wall_clock_ms}ms reported only)"
         else
             iter179_pass_or_regress_verdict_string="REGRESS"
-            iter179_emit_text_only_in_human_readable_mode_suppress_in_json_mode_to_keep_stdout_parse_clean "  ✗ ${human_readable_scenario_label}: forks=${iter186_observed_external_fork_count} > ceiling ${iter186_pinned_fork_count_gating_this_scenario}${iter186_perl_fragment_for_verdict_line} — REGRESSION: this script now forks more subprocesses than pinned; wall clock ${observed_median_wall_clock_ms}ms"
+            # The trailing wall-clock number is labelled "ungated" on purpose.
+            # This is a FORK-count failure, but the line carries a millisecond
+            # figure, and a log reader matching loosely on "wall clock" would
+            # file a real, load-invariant regression under the contention
+            # bucket — laundering a genuine defect into a known flake. Same
+            # hazard class as the skip line above, one severity lower (this line
+            # is a failure either way). The canonical classifier anchors on
+            # `median=…ms > cap=…ms`, which this deliberately does not match.
+            iter179_emit_text_only_in_human_readable_mode_suppress_in_json_mode_to_keep_stdout_parse_clean "  ✗ ${human_readable_scenario_label}: forks=${iter186_observed_external_fork_count} > ceiling ${iter186_pinned_fork_count_gating_this_scenario}${iter186_perl_fragment_for_verdict_line} — REGRESSION: this script now forks more subprocesses than pinned. This is NOT a timing failure; ungated wall clock was ${observed_median_wall_clock_ms}ms"
             ITER174_TOTAL_ASSERTIONS_FAILED=$((ITER174_TOTAL_ASSERTIONS_FAILED + 1))
         fi
     else


### PR DESCRIPTION
Refs #117, #118.

## The defect, one severity below the landmine already removed

A fork-count regression printed a line ending in a bare `wall clock 176ms`. That number is **reported only** — the gate is the fork count — but the line reads like a timing failure to anything scanning for one.

This is the same shape as the `CC_SKILLS_SKIP_PERF_TIMING` success line that used to carry the literal text `median=NNNms > cap=NNNms`, which had already fooled a log classifier into reporting a passing run as a wall-clock failure. That one was removed at source rather than asking consumers to anchor correctly forever; this is the same fix applied one severity lower.

**It was working correctly by luck of anchoring.** The classifier keys on the specific `median=NNNms > cap=NNNms` form, so a fork-regression line fell through to `UNKNOWN — matches no known mechanism; investigate rather than assume`, which is the right destination. But correctness depended on every present and future reader anchoring exactly as tightly. The line now reads:

```
This is NOT a timing failure; ungated wall clock was NNNms
```

## Verification

Negative control 4 re-run after the change — the pre-iter-167 per-commit fan-out re-injected:

```
forks 3 → 18      ✗ A5 still fails      exit=1      checksum-verified restore
```

Suite: **3/3 at 113/113.**

## Context: why the fork gate exists at all

Recorded here because the argument is easy to mistake for "wall clock is noisy", which is the weaker claim. The old cap **false-negatived every fork regression injected against it** — 1317 ms, 547 ms, and 173 ms, all comfortably under cap — while false-positiving under load. The mechanism is that the cap `200 + 21 × backlog` was calibrated when the aggregator invoked `git log` **2N+1 times**; iter-167 collapsed that to a single batched call, making true cost O(1) at a measured 3 forks. **The cap therefore grows to accommodate work the code no longer does**, and negative control 4 slipped under it because the cap had been sized for precisely that fan-out.

Measured across one afternoon, with nothing about the aggregator touched: backlog `5 → 11 → 12 → 13`, cap `305 → 431 → 452 → 473 ms`. **A threshold that moves while nobody edits it**, whose real strictness is a function of release cadence rather than of code.

## Note on A1–A4, deliberately not converted

They share the construction but currently sit at 81–93% headroom. With the direction of the defect corrected, the argument for converting them changes: they are **not** on a tightening threshold — they are on thresholds that will silently **loosen** if anyone ever optimises those scripts' cost class, exactly as happened here. That is a weaker urgency but a more interesting failure mode, and it is left under-argued in the file rather than asserted, since each would need its own measured fork profile and its own negative control.
