### PR TITLE
fix(hooks): finish #109 — generators still wrote bad timeouts

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -137,7 +137,7 @@ a hand-rolled regex.
         "hooks": [{
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/hooks/my-hook.mjs",
-          "timeout": 5000
+          "timeout": 5
         }]
       }
     ],
@@ -149,15 +149,17 @@ a hand-rolled regex.
 
 ## Timeout Values
 
-Timeouts are in **milliseconds**:
+Timeouts are in **seconds**. Upstream: "Seconds before canceling. … Defaults: 600 for command, http, and mcp_tool" — [hooks reference](https://docs.claude.com/en/docs/claude-code/hooks).
 
 | Value | Duration | Use Case          |
 | ----- | -------- | ----------------- |
-| 5000  | 5s       | Simple validation |
-| 15000 | 15s      | Git operations    |
-| 30000 | 30s      | Network calls     |
+| 5     | 5s       | Simple validation |
+| 15    | 15s      | Git operations    |
+| 30    | 30s      | Network calls     |
 
-**Common mistake**: Using `15` instead of `15000` results in 15ms timeout.
+This table said **milliseconds** until 2026-09-04, and that single line is how dozens of hook entries across the marketplace came to be written three digits too large: a `5000` meant as five seconds parks a _blocking_ hook for 83 minutes, and one Stop hook was left at 30000 — eight hours twenty. `scripts/hooks.schema.json` now caps the field at 600, so the wrong unit fails validation instead of shipping. See issue [#109](https://github.com/terrylica/cc-skills/issues/109).
+
+**Common mistake**: writing `15000` when you mean fifteen seconds. That is four hours ten minutes, and on a blocking hook it is indistinguishable from a hang. `15` is the correct value; this note previously advised the exact opposite.
 
 ## Network-Calling Hooks (Critical Warning)
 
@@ -2104,7 +2106,7 @@ Operators get a single discoverable artifact (20 marker sections in alphabetical
 | ---- | ---------------------------------------------------------------------------------------------------- |
 | 1    | iter-114 audit-task registry has all 4 documented exports                                            |
 | 2    | Registry contains all 8 iter-114 baseline audit markers                                              |
-| 3    | Every `consumerAuditTaskSourceFileRelativePath` references an existing `tasks/audit-*.sh` file |
+| 3    | Every `consumerAuditTaskSourceFileRelativePath` references an existing `tasks/audit-*.sh` file       |
 | 4    | iter-113 doc generator renders all 8 audit-task marker sections in dedicated audit-task catalog      |
 | 5    | Lookup-by-name helper resolves known marker with full field set; returns undefined for unknown       |
 | 6    | iter-113 generator idempotency invariant still holds with two-registry input (no drift on `--check`) |
@@ -2515,17 +2517,17 @@ Use TypeScript/Bun as the default for new hooks. Only use bash for simple patter
 
 ## Plugins with Hooks
 
-| Plugin               | Hook Types                    | Purpose                             |
-| -------------------- | ----------------------------- | ----------------------------------- |
+| Plugin               | Hook Types                    | Purpose                     |
+| -------------------- | ----------------------------- | --------------------------- |
 | `itp-hooks`          | PreToolUse, PostToolUse, Stop | Workflow + GPU optimization |
-| `ru`                 | PreToolUse, Stop              | Autonomous loop control             |
-| `gh-tools`           | PreToolUse, PostToolUse       | GitHub CLI enforcement              |
-| `dotfiles-tools`     | PostToolUse, Stop             | Chezmoi sync reminder               |
-| `statusline-tools`   | Stop                          | Session metrics                     |
-| `productivity-tools` | PreToolUse                    | Calendar event management           |
-| `gmail-commander`    | Stop                          | Bot lifecycle management            |
-| `calcom-commander`   | Stop                          | Bot lifecycle management            |
-| `tts-tg-sync`        | Stop                          | TTS/bot process cleanup             |
+| `ru`                 | PreToolUse, Stop              | Autonomous loop control     |
+| `gh-tools`           | PreToolUse, PostToolUse       | GitHub CLI enforcement      |
+| `dotfiles-tools`     | PostToolUse, Stop             | Chezmoi sync reminder       |
+| `statusline-tools`   | Stop                          | Session metrics             |
+| `productivity-tools` | PreToolUse                    | Calendar event management   |
+| `gmail-commander`    | Stop                          | Bot lifecycle management    |
+| `calcom-commander`   | Stop                          | Bot lifecycle management    |
+| `tts-tg-sync`        | Stop                          | TTS/bot process cleanup     |
 
 ## Related ADRs
 

--- a/plugins/dotfiles-tools/scripts/manage-hooks.sh
+++ b/plugins/dotfiles-tools/scripts/manage-hooks.sh
@@ -131,7 +131,7 @@ do_install() {
     info "Created backup: settings.json.backup.$timestamp"
 
     # Prepare hook entry (using $HOME literal, not expanded)
-    local posttooluse_entry='{"matcher":"Edit|Write","hooks":[{"type":"command","command":"$HOME/.claude/plugins/marketplaces/cc-skills/plugins/dotfiles-tools/hooks/chezmoi-sync-reminder.sh","timeout":5000}]}'
+    local posttooluse_entry='{"matcher":"Edit|Write","hooks":[{"type":"command","command":"$HOME/.claude/plugins/marketplaces/cc-skills/plugins/dotfiles-tools/hooks/chezmoi-sync-reminder.sh","timeout":5}]}'
 
     # Create temp file for atomic write
     local temp_file

--- a/plugins/itp-hooks/skills/hooks-development/references/hook-templates.md
+++ b/plugins/itp-hooks/skills/hooks-development/references/hook-templates.md
@@ -18,7 +18,7 @@ Every plugin with hooks must have `hooks/hooks.json` using this canonical object
           {
             "type": "command",
             "command": "$HOME/.claude/plugins/marketplaces/cc-skills/plugins/<plugin>/hooks/<script>",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -30,7 +30,7 @@ Every plugin with hooks must have `hooks/hooks.json` using this canonical object
           {
             "type": "command",
             "command": "$HOME/.claude/plugins/marketplaces/cc-skills/plugins/<plugin>/hooks/<script>",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -41,7 +41,7 @@ Every plugin with hooks must have `hooks/hooks.json` using this canonical object
           {
             "type": "command",
             "command": "$HOME/.claude/plugins/marketplaces/cc-skills/plugins/<plugin>/hooks/<script>",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       }
@@ -53,7 +53,7 @@ Every plugin with hooks must have `hooks/hooks.json` using this canonical object
 **Rules**:
 
 - `matcher` — Regex against tool name. **Required** for PreToolUse/PostToolUse. **Optional** for Stop.
-- `timeout` — Milliseconds. Default is 600000 (10 min). Set explicit lower values for fast-fail hooks.
+- `timeout` — **Seconds**, not milliseconds. Default is 600 (10 min). Set explicit lower values for fast-fail hooks; `scripts/hooks.schema.json` rejects anything above 600, because a four-digit value here is the millisecond spelling and holds a blocking hook for over an hour (issue [#109](https://github.com/terrylica/cc-skills/issues/109)).
 - **Always use `$HOME`-based paths**, never `${CLAUDE_PLUGIN_ROOT}` (it's not a shell env var — see Common Pitfalls in lifecycle-reference.md).
 - Include only the event types your plugin uses. Most plugins only need 1-2.
 
@@ -101,7 +101,7 @@ PREFLIGHT_EOF
         {
           "type": "command",
           "command": "$HOME/.claude/plugins/.../hooks/your-hook.sh",
-          "timeout": 5000
+          "timeout": 5
         }
       ]
     }

--- a/plugins/itp-hooks/skills/hooks-development/references/lifecycle-reference.md
+++ b/plugins/itp-hooks/skills/hooks-development/references/lifecycle-reference.md
@@ -755,7 +755,7 @@ Plugin hooks are declared in `hooks/hooks.json` and synced to `~/.claude/setting
           {
             "type": "command",
             "command": "$HOME/.claude/plugins/marketplaces/cc-skills/plugins/<plugin>/hooks/<script>",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       }

--- a/plugins/itp/scripts/manage-hooks.sh
+++ b/plugins/itp/scripts/manage-hooks.sh
@@ -146,9 +146,9 @@ do_install() {
     info "Created backup: settings.json.backup.$timestamp"
 
     # Prepare hook entries (using $HOME literal, not expanded)
-    # Timeouts are in milliseconds (Claude Code hook standard)
-    local posttooluse_entry='{"matcher":"Bash|Write|Edit","hooks":[{"type":"command","command":"$HOME/.claude/plugins/marketplaces/cc-skills/plugins/itp-hooks/hooks/posttooluse-reminder.sh","timeout":10000}]}'
-    local fakedata_entry='{"matcher":"Write","hooks":[{"type":"command","command":"bun $HOME/.claude/plugins/marketplaces/cc-skills/plugins/itp-hooks/hooks/pretooluse-fake-data-guard.mjs","timeout":5000}]}'
+    # Timeouts are in SECONDS (Claude Code hook standard; see scripts/hooks.schema.json)
+    local posttooluse_entry='{"matcher":"Bash|Write|Edit","hooks":[{"type":"command","command":"$HOME/.claude/plugins/marketplaces/cc-skills/plugins/itp-hooks/hooks/posttooluse-reminder.sh","timeout":10}]}'
+    local fakedata_entry='{"matcher":"Write","hooks":[{"type":"command","command":"bun $HOME/.claude/plugins/marketplaces/cc-skills/plugins/itp-hooks/hooks/pretooluse-fake-data-guard.mjs","timeout":5}]}'
 
     # Create temp file for atomic write
     local temp_file

--- a/plugins/plugin-dev/skills/skill-architecture/references/advanced-topics.md
+++ b/plugins/plugin-dev/skills/skill-architecture/references/advanced-topics.md
@@ -199,7 +199,7 @@ my-plugin/
           {
             "type": "command",
             "command": "bun $HOME/.claude/plugins/marketplaces/cc-skills/plugins/my-plugin/hooks/my-handler.ts",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       }

--- a/plugins/statusline-tools/scripts/manage-hooks.sh
+++ b/plugins/statusline-tools/scripts/manage-hooks.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
 SETTINGS_FILE="${HOME}/.claude/settings.json"
-HOOK_TIMEOUT=30000
+HOOK_TIMEOUT=30
 
 # Use marketplace path with $HOME for portability and auto-updates
 # This path is version-agnostic - updates automatically when plugin updates
@@ -149,7 +149,7 @@ cmd_install() {
     mv "$tmp_file" "$SETTINGS_FILE"
     log_success "Stop hook installed"
     log_info "  Script:  $HOOK_SCRIPT_SETTINGS"
-    log_info "  Timeout: ${HOOK_TIMEOUT}ms"
+    log_info "  Timeout: ${HOOK_TIMEOUT}s"
     log_info "Restart Claude Code for changes to take effect"
 }
 
@@ -241,7 +241,7 @@ cmd_status() {
                 select(.hooks[]?.command == $script) |
                 .hooks[] |
                 select(.command == $script) |
-                "    Timeout: \(.timeout // "default")ms"
+                "    Timeout: \(.timeout // "default")s"
             ' "$SETTINGS_FILE" 2>/dev/null)
             if [[ -n "$hook_info" ]]; then
                 echo "$hook_info"

--- a/plugins/tts-tg-sync/skills/tether/SKILL.md
+++ b/plugins/tts-tg-sync/skills/tether/SKILL.md
@@ -59,7 +59,7 @@ The hook is registered in the plugin's `hooks/hooks.json`:
           {
             "type": "command",
             "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/telegram-notify-stop.ts",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       }

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -1154,59 +1154,123 @@ async function validateHooksJsonStructure() {
 
   for (const scriptPath of hookScripts) {
     const relPath = relative(process.cwd(), scriptPath);
-    const pluginName = relPath.split("/")[1];
 
     try {
       const content = readFileSync(scriptPath, "utf8");
 
-      // Extract jq expressions that generate hook entries
-      // Pattern: jq -n --arg ... '{...}' or jq -n '{...}'
-      const jqExpressions = [];
-      const jqPattern = /jq\s+-n\s+(?:--arg\s+\w+\s+"[^"]*"\s*)*'(\{[^']+\})'/g;
-      let match;
+      // EVERY single-quoted object literal in the generator, however it is introduced.
+      //
+      // This previously required the literal to follow `jq -n`:
+      //     /jq\s+-n\s+(?:--arg\s+\w+\s+"[^"]*"\s*)*'(\{[^']+\})'/g
+      // Three hook entries across two generators are plain bash assignments instead --
+      //     local posttooluse_entry='{"matcher":"Bash|Write|Edit",…,"timeout":10000}'
+      // -- so they were read by NO check at all: this pattern skipped them, and the shipped-artifact
+      // loop below only globs `plugins/*/hooks/hooks.json`. Measured on 6f1c9e22: the validator
+      // reported "All 41 plugins valid" over a tree whose installer wrote a 10000-SECOND (2h47m)
+      // timeout onto a blocking PostToolUse hook. Issue #109, which the timeout fix did not finish.
+      const objectLiterals = [...content.matchAll(/'(\{[^']*\})'/g)].map((literal) => ({
+        expression: literal[1],
+        line: content.slice(0, literal.index).split("\n").length,
+      }));
 
-      while ((match = jqPattern.exec(content)) !== null) {
-        const lineNum = content.substring(0, match.index).split("\n").length;
-        jqExpressions.push({
-          expression: match[1],
-          fullMatch: match[0],
-          line: lineNum,
-        });
-      }
-
-      // Validate each extracted jq expression
-      for (const { expression, fullMatch, line } of jqExpressions) {
-        // Skip expressions that are clearly not hook entries
+      for (const { expression, line } of objectLiterals) {
+        // Skip literals that are clearly not hook entries
         if (!expression.includes("type") && !expression.includes("matcher")) {
           continue;
         }
 
-        // Run jq to get actual JSON output
+        let entry;
         try {
-          // Replace $cmd variable references with placeholder for validation
-          const testExpr = expression.replace(/\$\w+/g, '"placeholder"');
-          const jqCmd = `jq -n '${testExpr}'`;
-
-          const output = execSync(jqCmd, {
-            encoding: "utf8",
-            timeout: 5000,
-          }).trim();
-
-          const jsonOutput = JSON.parse(output);
-
-          // Determine what schema to validate against based on content
-          if (jsonOutput.matcher !== undefined) {
-            // This is a hookMatcher (PreToolUse, PostToolUse)
-            validateHookMatcher(jsonOutput, relPath, line, errors, warnings);
-          } else if (jsonOutput.hooks !== undefined) {
-            // This is a hookEventArray entry (Stop, SubagentStop)
-            validateHookEventEntry(jsonOutput, relPath, line, errors, warnings);
+          // A bash-literal entry is ALREADY valid JSON -- a `$HOME` inside a quoted value is just
+          // characters. Parse it as-is. The `$var -> "placeholder"` substitution below is right for
+          // a bare jq variable but CORRUPTS a shell variable inside a JSON string, turning
+          // {"command":"$HOME/x.sh"} into {"command":""placeholder"/x.sh"}, which then fails to
+          // parse and would be reported as an unreadable expression rather than validated.
+          entry = JSON.parse(expression);
+        } catch {
+          try {
+            const testExpr = expression.replace(/\$\w+/g, '"placeholder"');
+            entry = JSON.parse(
+              execSync(`jq -n '${testExpr}'`, { encoding: "utf8", timeout: 5000 }).trim()
+            );
+          } catch (parseErr) {
+            warnings.push(`${relPath}:${line}: Could not validate hook entry: ${parseErr.message}`);
+            continue;
           }
-        } catch (jqErr) {
-          warnings.push(
-            `${relPath}:${line}: Could not validate jq expression: ${jqErr.message}`
+        }
+
+        if (entry.matcher !== undefined) {
+          // hookMatcher (PreToolUse, PostToolUse)
+          validateHookMatcher(entry, relPath, line, errors, warnings);
+        } else if (entry.hooks !== undefined) {
+          // hookEventArray entry (Stop, SubagentStop)
+          validateHookEventEntry(entry, relPath, line, errors, warnings);
+        }
+      }
+
+      // SHAPE-INDEPENDENT TIMEOUT SCAN. This, not the widened extractor, is what closes #109.
+      //
+      // Entry extraction reads two shapes: `jq -n '{…}'` and `local entry='{…}'`. There is a THIRD,
+      // an object literal embedded in a multi-line jq PROGRAM with the value bound through --argjson:
+      //
+      //     jq --argjson timeout "$HOOK_TIMEOUT" '… .hooks.Stop += [{ … "timeout": $timeout }]'
+      //
+      // No `'{…}'` pattern can see that, and it concealed HOOK_TIMEOUT=30000 -- eight hours twenty
+      // minutes on a BLOCKING Stop hook. That is the largest wrong timeout in the repository, larger
+      // than the 18-hour value #124 was written to fix, and neither #124 nor a hand grep for
+      // oversized literals found it. A checker that only sees the shapes someone thought to enumerate
+      // will keep missing the next one.
+      //
+      // So do not reach the timeout THROUGH a parsed entry. Read every `"timeout":` binding straight
+      // out of the text, resolve it across at most two hops (jq arg -> shell variable), and bounds
+      // -check the number. Robust to a fourth shape nobody has written yet.
+      const { min: timeoutMin, max: timeoutMax } = resolveTimeoutBounds();
+      const timeoutBindings = [...content.matchAll(/"timeout"\s*:\s*(\$?[A-Za-z_]\w*|\d+)/g)].map(
+        (binding) => ({
+          token: binding[1],
+          line: content.slice(0, binding.index).split("\n").length,
+        }),
+      );
+
+      // A binding inside a literal the extractor DID parse is reported twice — once by the schema
+      // path above and once here. That is deliberate: the two reports rest on different evidence
+      // (a parsed entry vs. raw text), and suppressing one would mean trusting the extractor to
+      // decide what the scan is allowed to see, which is the coupling that produced the blind spot.
+      for (const { token, line } of timeoutBindings) {
+        const seconds = resolveGeneratorTimeoutValue(token, content);
+
+        if (seconds === null) {
+          // An unresolvable value must never read as a passing value.
+          errors.push(
+            `${relPath}:${line}: writes "timeout": ${token}, which cannot be resolved to a number ` +
+              `from this file, so its value goes unchecked. Bind it to a literal or to a plain ` +
+              `NAME=<digits> assignment that this scan can follow.`
+          );
+        } else if (timeoutMax === undefined) {
+          errors.push(
+            `${relPath}:${line}: cannot locate timeout bounds in hooks.schema.json, so the ` +
+              `generator timeout constraint is unenforceable. Fix resolveTimeoutBounds() rather ` +
+              `than leaving the value unchecked.`
+          );
+        } else if (seconds < timeoutMin || seconds > timeoutMax) {
+          const via = token.startsWith("$") ? ` (via ${token})` : "";
+          errors.push(
+            `${relPath}:${line}: timeout must be ${timeoutMin}-${timeoutMax} SECONDS, got ` +
+              `${seconds}${via}. That is ${describeDurationInSeconds(seconds)}; a blocking hook ` +
+              `holds the session for exactly that long.`
           );
         }
+      }
+
+      // ANTI-VACUITY. The scan above is `for (...) { check }`, which reports success over an empty
+      // set -- the same shape that let these values ship in the first place. If the file writes a
+      // `"timeout"` key at all but the scan bound nothing, the spelling has moved and this check
+      // has silently stopped covering the file.
+      if (content.includes('"timeout"') && timeoutBindings.length === 0) {
+        errors.push(
+          `${relPath}: contains a "timeout" key but the scan resolved no binding, so no timeout ` +
+            `in this generator is checked. Widen the scan rather than leaving it blind.`
+        );
       }
     } catch (err) {
       warnings.push(`${relPath}: Could not read script: ${err.message}`);
@@ -1265,6 +1329,58 @@ async function validateHooksJsonStructure() {
   }
 
   return { errors, warnings };
+}
+
+/**
+ * The `timeout` bounds, read from hooks.schema.json rather than restated.
+ *
+ * ONE lookup, used by both the shipped-artifact check and the generator scan. The bound existed in
+ * three places before #124 (a hardcoded 600000, a doc line saying "milliseconds", and the schema),
+ * and they disagreed; that disagreement is what shipped 53 wrong values. `max` is deliberately
+ * returned as `undefined` when the lookup path breaks, so callers must handle "unknown" explicitly
+ * instead of receiving a permissive default.
+ */
+function resolveTimeoutBounds() {
+  const bound =
+    hooksSchema?.$defs?.hookDefinition?.properties?.timeout ??
+    hooksSchema?.definitions?.hookDefinition?.properties?.timeout;
+  return { min: bound?.minimum ?? 1, max: bound?.maximum };
+}
+
+/**
+ * Resolve a generator's `"timeout":` token to a number, or null when it cannot be resolved.
+ *
+ * Handles the two indirections that actually occur: a jq argument bound from a shell variable
+ * (`--argjson timeout "$HOOK_TIMEOUT"`), and that shell variable's own assignment
+ * (`HOOK_TIMEOUT=30000`). Returning null rather than a default is the point — an unresolved
+ * timeout is reported as unchecked, never as acceptable.
+ */
+function resolveGeneratorTimeoutValue(token, content) {
+  if (/^\d+$/.test(token)) return Number(token);
+
+  const jqArgName = token.replace(/^\$/, "");
+  // Hop 1: jq --argjson <name> "$SHELL_VAR" / "${SHELL_VAR}"
+  const jqBinding = content.match(
+    new RegExp(String.raw`--argjson\s+${jqArgName}\s+"\$\{?(\w+)\}?"`),
+  );
+  const shellName = jqBinding ? jqBinding[1] : jqArgName;
+
+  // Hop 2: NAME=<digits>, with or without local/readonly/declare
+  const assignment = content.match(
+    new RegExp(
+      String.raw`(?:^|\n)\s*(?:local\s+|readonly\s+|declare\s+(?:-\w+\s+)?)?${shellName}=(\d+)\b`,
+    ),
+  );
+  return assignment ? Number(assignment[1]) : null;
+}
+
+/** Render a seconds value the way a reader feels it, so "30000" reads as the outage it is. */
+function describeDurationInSeconds(seconds) {
+  if (seconds < 60) return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  if (hours === 0) return `${minutes} minutes`;
+  return `${hours}h${String(minutes).padStart(2, "0")}m`;
 }
 
 /**
@@ -1376,10 +1492,7 @@ function validateHookDefinition(hook, location, errors, warnings) {
   // message said "ms", which is how 53 entries across 10 plugins came to be written as
   // milliseconds in the first place.
   if (hook.timeout !== undefined) {
-    const bound = hooksSchema?.$defs?.hookDefinition?.properties?.timeout
-      ?? hooksSchema?.definitions?.hookDefinition?.properties?.timeout;
-    const min = bound?.minimum ?? 1;
-    const max = bound?.maximum;
+    const { min, max } = resolveTimeoutBounds();
 
     if (max === undefined) {
       // Fail loudly rather than silently skipping: a schema whose shape moved must not read as


### PR DESCRIPTION
Closes #109.

PR #124 corrected 53 hook timeouts and tightened the schema to `600`. It did not finish the job: the generators that **write** those values were left wrong, and the validator it added is structurally incapable of reading them. I found this while checking whether #109 could be closed — the closing comment would have cited a merge that left the defect live.

## Four live sites, none of them documentation

`manage-hooks.sh install` writes these into the user's real `~/.claude/settings.json`:

| file:line | value | what it means |
| --- | --- | --- |
| `plugins/dotfiles-tools/scripts/manage-hooks.sh:134` | `5000` | 83 minutes |
| `plugins/itp/scripts/manage-hooks.sh:150` | `10000` | 2h47m |
| `plugins/itp/scripts/manage-hooks.sh:151` | `5000` | 83 minutes |
| `plugins/statusline-tools/scripts/manage-hooks.sh:21` | `30000` | **8h20m, on a blocking Stop hook** |

The last is the largest wrong timeout in the repository — larger than the 65000 (18 hours) that #124 was written to fix. No check had ever seen it, my own grep for oversized literals missed it, and #124 did not touch it.

**It surfaced because the anti-vacuity assertion reported that a file wrote a timeout no entry had reached.** The assertion found a defect its author had not.

## Why every check was blind

Three different spellings of a hook entry live in these generators:

```bash
jq -n '{…}'                                            # 1 — the ONLY shape the extractor matched
local entry='{"matcher":…,"timeout":10000}'            # 2 — plain bash literal, skipped entirely
jq --argjson timeout "$HOOK_TIMEOUT" '… {"timeout": $timeout} …'   # 3 — embedded jq PROGRAM
```

The extractor at `validate-plugins.mjs:1165` required `jq -n`, so shapes 2 and 3 were invisible. The shipped-artifact loop #124 added globs `plugins/*/hooks/hooks.json`, so it could not help — these are `.sh`. **Neither path read the lines at all**, which is how `validate-plugins.mjs` reported `All 41 plugins valid` over an installer configuring a 2h47m blocking hook.

That is the same defect class #109 is about: a check reporting green over input it never opened.

## The fix is not a fourth pattern

Enumerating shapes is precisely what failed. The timeout is now read straight out of the text and resolved across at most two hops (jq arg → shell variable), so **the spelling of the entry no longer decides whether the value gets checked**. Entry extraction is still widened to shape 2 for schema and nesting validation, but it no longer gates timeout validation.

- **Unresolvable resolves to an error, never a pass** — the value is reported as *unchecked* rather than accepted.
- **An anti-vacuity assertion** fires when a file contains a `"timeout"` key but the scan bound nothing, so the next new spelling fails loudly instead of silently widening the hole.
- The schema bound is now read once by `resolveTimeoutBounds()` and shared, rather than restated. The bound previously existed in three disagreeing places, and that disagreement is what shipped 53 wrong values.

## The propagation vector is closed too

This issue's title is *"one doc line propagated the error"*. That line and its table were still present, still copy-pasteable:

- `docs/HOOKS.md` — "Timeouts are in **milliseconds**", plus a table mapping `5000 → 5s`
- `hook-templates.md:56` — "`timeout` — Milliseconds. Default is 600000"
- eight code samples across `hook-templates.md`, `lifecycle-reference.md`, `advanced-topics.md`, `tether/SKILL.md`

`docs/HOOKS.md` also carried, immediately below the corrected table, **"Common mistake: Using `15` instead of `15000` results in 15ms timeout"** — teaching the exact error being fixed. Reversed.

Deliberately **not** changed: `firecrawl-research-patterns/SKILL.md:118` (a Firecrawl API parameter that genuinely is milliseconds), `gh-tools url-routing.md:36` (a server-side cap), and `docs/design/2025-12-27-*/spec.md` (frozen archive).

## Verification

**Baseline first.** The validator was shown *passing* over the known-bad tree, then **red at 7 errors**, then green after the values were fixed. A green run on its own would have proven nothing.

**Mutation table: 7/7 killed**, restores byte-identical by `sha256`, post-restore baseline re-checked green.

| mutation | result |
| --- | --- |
| literal reverted to the ms spelling | killed — reports `1h23m` |
| the two-hop shell variable reverted | killed — reports `8h20m` |
| `--argjson` hop broken, value unresolvable | killed — `cannot be resolved`, not a pass |
| a timeout spelled so the scan cannot bind it | killed — `resolved no binding` |
| schema bound made unreachable | killed — `unenforceable` |
| **false-positive:** maximum legal value (600) | **stayed green** |
| **false-positive:** minimum legal value (1) | **stayed green** |

The last two matter as much as the first five: a guard that fires on correct work is a guard the next person disables.

Also: `bash -n` clean on all three modified generators, both jq entries re-checked as valid JSON, and `validate-plugins.mjs` at **41 plugins, 0 errors, 0 warnings**.

## Left open on purpose

`plugins/itp/scripts/manage-hooks.sh` points `do_install` at `posttooluse-reminder.sh`, which does not exist — the file is `.ts`. The installer `die`s at its own existence check, so no broken hook is installed, but that whole path is inert. And the hooks it would install are already shipped in `plugins/itp-hooks/hooks/hooks.json`, so repairing it naively would double-register them.

Whether that installer should be repaired or retired is a design question, not a unit bug, so it is filed as #127 rather than decided inside a timeout fix. #127 also notes that `statusline-tools` installs a hook that is *not* in its `hooks.json`, so at least one generator is doing something the shipped artifact does not.
