### PR TITLE
fix(itp-hooks): the review-round gate's reviewable bit never expired

### DIFF
--- a/plugins/itp-hooks/hooks/lib/review-round-artifact.test.ts
+++ b/plugins/itp-hooks/hooks/lib/review-round-artifact.test.ts
@@ -91,8 +91,10 @@ describe("classify — commands that must be ALLOWED", () => {
   const allowed = [
     // A draft never enters the reviewer's queue, so it is not a review event.
     "gh pr create --draft --title x --body-file b.md",
-    // --undo REMOVES work from the queue. Gating it would block the remedy the gate recommends.
-    "gh pr ready 613 --undo",
+    // NOTE: `gh pr ready --undo` is NOT in this list any more. It is still never gated, but it is
+    // no longer INVISIBLE: it now classifies as `pr-undraft` so the gate can clear the reviewable
+    // mark. See the dedicated describe block below — collapsing it to null is what let the mark
+    // survive a re-draft forever.
     // The words appear inside an argument, not at a command position.
     'echo "then run gh pr ready 613"',
     'gh pr comment 1 --body "Rebased; CI green."',
@@ -107,6 +109,30 @@ describe("classify — commands that must be ALLOWED", () => {
       expect(classify(command).kind).toBeNull();
     });
   }
+});
+
+describe("leaving the review queue is observed, not ignored", () => {
+  // The first version returned {kind:null} here, making `--undo` indistinguishable from `ls -la`.
+  // The gate therefore had no moment at which to notice the branch had left the queue, and the
+  // reviewable mark outlived the re-draft — while this module's own comment claimed `--undo`
+  // "removes work from the queue". The comment described an intent the code did not implement.
+  const undoCases = [
+    "gh pr ready 613 --undo",
+    "GH_ORGS='Eon Labs' gh pr ready 613 --undo",
+    "/opt/homebrew/bin/gh pr ready 613 --undo",
+  ];
+  for (const command of undoCases) {
+    test(`pr-undraft: ${command.slice(0, 48)}`, () => {
+      expect(classify(command).kind).toBe("pr-undraft");
+    });
+  }
+
+  test("a --undo mentioned inside a quoted body is NOT a transition", () => {
+    // Otherwise a PR comment discussing `--undo` would silently clear the mark.
+    expect(classify('gh pr comment 1 --body "run gh pr ready 613 --undo next"').kind).not.toBe(
+      "pr-undraft",
+    );
+  });
 });
 
 describe("override", () => {

--- a/plugins/itp-hooks/hooks/lib/review-round-artifact.ts
+++ b/plugins/itp-hooks/hooks/lib/review-round-artifact.ts
@@ -86,10 +86,23 @@ const READY_UNDO = /(?:^|\s)--undo(?=\s|$)/;
 
 const hasFlag = (command: string, flag: RegExp) => flag.test(withoutQuotedSpans(command));
 
-export type GatedKind = "pr-ready" | "pr-create" | "push" | "inline-body";
+/**
+ * `pr-undraft` is NOT gated. It is here because collapsing it to `null` -- which is what the first
+ * version did -- makes it indistinguishable from `ls -la`, and the gate then has no moment at which
+ * to notice that the branch left the review queue.
+ *
+ * The consequence of that collapse was measured: the reviewable bit survived `gh pr ready --undo`
+ * forever, so every push to a re-drafted PR stayed fully gated while this file's own comment
+ * asserted that `--undo` "removes work from the queue". The comment described an intent the code
+ * did not implement. Naming the transition is what lets the gate act on it.
+ */
+export type CommandKind = "pr-ready" | "pr-create" | "push" | "inline-body" | "pr-undraft";
+
+/** @deprecated Retained so existing imports keep compiling; prefer {@link CommandKind}. */
+export type GatedKind = CommandKind;
 
 export interface Classification {
-  readonly kind: GatedKind | null;
+  readonly kind: CommandKind | null;
   /** Why this command was picked up, quoted back to the operator so a misfire is diagnosable. */
   readonly matched: string;
 }
@@ -111,7 +124,7 @@ const PUBLISHES_A_BODY = ghCommand(
 
 export function classify(command: string): Classification {
   if (hasFlag(command, READY_UNDO) && GH_PR_READY.test(command)) {
-    return { kind: null, matched: "" };
+    return { kind: "pr-undraft", matched: "gh pr ready --undo" };
   }
 
   // INLINE BODY IS CHECKED FIRST, and the order is load-bearing rather than incidental. It is a

--- a/plugins/itp-hooks/hooks/lib/review-round-state.test.ts
+++ b/plugins/itp-hooks/hooks/lib/review-round-state.test.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env bun
+/**
+ * The reviewable-branch lifecycle, against REAL git repositories.
+ *
+ * WHY THIS FILE EXISTS. The gate shipped with tests for its pure classifier and validator and none
+ * at all for this state machine, and every defect it is now being fixed for lived here: the mark was
+ * never cleared by anything, `gh pr ready --undo` silently did not clear it despite a comment saying
+ * it removed work from the queue, the two stores disagreed on how to spell a branch name, and a
+ * recreated branch inherited the mark of the deleted one. None of those are visible from the pure
+ * functions, which is precisely why testing only the pure functions found none of them.
+ *
+ * These use real `git init` repositories rather than a mocked git, because the fix turns on
+ * `git merge-base --is-ancestor` actually behaving like git.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  STATE_ROOT,
+  collectFacts,
+  identifyRepo,
+  isBranchReviewable,
+  markBranchReviewable,
+  unmarkBranchReviewable,
+} from "./review-round-state.ts";
+
+const created: string[] = [];
+
+function sh(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+}
+
+/** A throwaway repo with one commit on `main`, and no origin so the slug is the directory name. */
+function makeRepo(prefix: string): { dir: string; slug: string } {
+  const dir = mkdtempSync(join(tmpdir(), `rrs-${prefix}-`));
+  created.push(dir);
+  sh(["init", "-q", "-b", "main"], dir);
+  sh(["config", "user.email", "t@e.st"], dir);
+  sh(["config", "user.name", "t"], dir);
+  writeFileSync(join(dir, "a.txt"), "one\n");
+  sh(["add", "-A"], dir);
+  sh(["commit", "-qm", "base"], dir);
+  return { dir, slug: dir.split("/").pop() as string };
+}
+
+function commit(dir: string, text: string): void {
+  writeFileSync(join(dir, "a.txt"), text);
+  sh(["add", "-A"], dir);
+  sh(["commit", "-qm", "work"], dir);
+}
+
+function idOf(dir: string) {
+  const id = identifyRepo(dir);
+  if (id === null) throw new Error(`identifyRepo returned null for ${dir}`);
+  return id;
+}
+
+afterEach(() => {
+  for (const dir of created.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(join(STATE_ROOT, dir.split("/").pop() as string), { recursive: true, force: true });
+  }
+});
+
+describe("BASELINE", () => {
+  test("an honest mark makes the branch reviewable", () => {
+    const { dir } = makeRepo("baseline");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+
+    expect(isBranchReviewable(id)).toBe(false); // nothing recorded yet
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+    expect(isBranchReviewable(id)).toBe(true);
+  });
+});
+
+describe("the mark expires instead of lasting forever", () => {
+  test("committing further on the SAME branch keeps it reviewable", () => {
+    // The review is still pending; new commits are exactly the fix rounds the gate meters.
+    const { dir } = makeRepo("forward");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+
+    commit(dir, "one\ntwo\nthree\n");
+    expect(isBranchReviewable(id)).toBe(true);
+  });
+
+  test("a RECREATED branch of the same name does NOT inherit the mark", () => {
+    // The defect this replaced: the store held bare branch names forever, so deleting a merged
+    // branch and later creating an unrelated one with the same name produced a branch that was
+    // "reviewable" from its first push, with no PR in existence.
+    const { dir } = makeRepo("reuse");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+    expect(isBranchReviewable(id)).toBe(true);
+
+    sh(["checkout", "-q", "main"], dir);
+    sh(["branch", "-qD", "feature"], dir);
+    sh(["checkout", "-qb", "feature"], dir); // same NAME, different history
+    commit(dir, "unrelated\n");
+
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+
+  test("a mark from an unrelated commit does not apply", () => {
+    const { dir } = makeRepo("unrelated");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    // A sha that exists but is not an ancestor of HEAD.
+    sh(["checkout", "-q", "main"], dir);
+    sh(["checkout", "-qb", "sidebranch"], dir);
+    commit(dir, "side\n");
+    const sideSha = sh(["rev-parse", "HEAD"], dir).trim();
+    sh(["checkout", "-q", "feature"], dir);
+
+    markBranchReviewable(id, sideSha);
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+
+  test("a sha that no longer exists reads as not reviewable, and does not throw", () => {
+    const { dir } = makeRepo("missing");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    markBranchReviewable(idOf(dir), "0".repeat(40));
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+});
+
+describe("leaving the queue", () => {
+  test("unmark clears it", () => {
+    const { dir } = makeRepo("undo");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+    expect(isBranchReviewable(id)).toBe(true);
+
+    unmarkBranchReviewable(id);
+    expect(isBranchReviewable(id)).toBe(false);
+  });
+
+  test("unmark leaves OTHER branches' marks intact", () => {
+    // A blanket "clear the store" would pass the test above and silently unmeter every other
+    // in-flight PR in the same repository.
+    const { dir } = makeRepo("undo-scope");
+    sh(["checkout", "-qb", "alpha"], dir);
+    commit(dir, "alpha\n");
+    const alpha = idOf(dir);
+    markBranchReviewable(alpha, sh(["rev-parse", "HEAD"], dir).trim());
+
+    sh(["checkout", "-q", "main"], dir);
+    sh(["checkout", "-qb", "beta"], dir);
+    commit(dir, "beta\n");
+    const beta = idOf(dir);
+    markBranchReviewable(beta, sh(["rev-parse", "HEAD"], dir).trim());
+
+    unmarkBranchReviewable(beta);
+    expect(isBranchReviewable(beta)).toBe(false);
+
+    sh(["checkout", "-q", "alpha"], dir);
+    expect(isBranchReviewable(idOf(dir))).toBe(true);
+  });
+
+  test("unmarking a branch that was never marked is a no-op, not a crash", () => {
+    const { dir } = makeRepo("undo-absent");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    expect(() => unmarkBranchReviewable(idOf(dir))).not.toThrow();
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+});
+
+function factsOf(dir: string) {
+  const f = collectFacts(dir);
+  if (f === null) throw new Error("collectFacts returned null");
+  return f;
+}
+
+describe("a new file is part of the change", () => {
+  test("an untracked file appears in changedPaths", () => {
+    // `git diff` cannot see untracked files, so before this the gate exempted every newly-added
+    // file from the self-review requirement entirely — the files most likely to contain code
+    // nobody has read. Found by running the gate's own CLI on the commit that introduced it.
+    const { dir } = makeRepo("untracked");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    writeFileSync(join(dir, "brand-new.ts"), "export const x = 1;\n");
+
+    expect(factsOf(dir).changedPaths).toContain("brand-new.ts");
+  });
+
+  test("editing an untracked file changes the diff hash", () => {
+    // Without this, a pass could be recorded and an entire new module added afterwards while the
+    // record stayed valid — S2 would not notice, because S2 hashes a diff the file is absent from.
+    const { dir } = makeRepo("untracked-hash");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    writeFileSync(join(dir, "brand-new.ts"), "export const x = 1;\n");
+    const before = factsOf(dir).diffText;
+
+    writeFileSync(join(dir, "brand-new.ts"), "export const x = 2;\n");
+    expect(factsOf(dir).diffText).not.toBe(before);
+  });
+
+  test("a gitignored file is NOT treated as part of the change", () => {
+    // Build output and caches must not demand a verdict, or the gate fires constantly on work
+    // nobody wrote — the profile of a guard that gets switched off.
+    const { dir } = makeRepo("ignored");
+    sh(["checkout", "-qb", "feature"], dir);
+    writeFileSync(join(dir, ".gitignore"), "junk/\n");
+    sh(["add", "-A"], dir);
+    sh(["commit", "-qm", "ignore"], dir);
+    mkdirSync(join(dir, "junk"), { recursive: true });
+    writeFileSync(join(dir, "junk", "out.bin"), "generated\n");
+
+    expect(factsOf(dir).changedPaths.some((p) => p.startsWith("junk/"))).toBe(false);
+  });
+});
+
+describe("store robustness", () => {
+  test("a legacy v1 array store is discarded rather than trusted or crashed on", () => {
+    // v1 held bare names and no sha. There is no honest migration -- the reviewed commit simply was
+    // not recorded -- and inventing one would re-arm a mark that can never expire.
+    const { dir, slug } = makeRepo("legacy");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const path = join(STATE_ROOT, slug, "reviewable-branches.json");
+    mkdirSync(join(STATE_ROOT, slug), { recursive: true });
+    writeFileSync(path, JSON.stringify(["feature"], null, 2));
+
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+
+  test("an unparseable store reads as not reviewable rather than throwing", () => {
+    const { dir, slug } = makeRepo("corrupt");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    mkdirSync(join(STATE_ROOT, slug), { recursive: true });
+    writeFileSync(join(STATE_ROOT, slug, "reviewable-branches.json"), "{ not json");
+
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+
+  test("re-marking replaces the anchor rather than accumulating duplicates", () => {
+    const { dir, slug } = makeRepo("remark");
+    sh(["checkout", "-qb", "feature"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+    commit(dir, "one\ntwo\nthree\n");
+    const second = sh(["rev-parse", "HEAD"], dir).trim();
+    markBranchReviewable(id, second);
+
+    const store = JSON.parse(
+      readFileSync(join(STATE_ROOT, slug, "reviewable-branches.json"), "utf8"),
+    );
+    expect(store.branches.length).toBe(1);
+    expect(store.branches[0].sha).toBe(second);
+  });
+
+  test("a slash-bearing branch name round-trips", () => {
+    // Both stores must agree on the key. They did not: the artifact path sanitised the name while
+    // the reviewable list stored it raw.
+    const { dir } = makeRepo("slashes");
+    sh(["checkout", "-qb", "fix/2026-09-04/nested"], dir);
+    commit(dir, "one\ntwo\n");
+    const id = idOf(dir);
+    expect(id.branch).toBe("fix/2026-09-04/nested");
+
+    markBranchReviewable(id, sh(["rev-parse", "HEAD"], dir).trim());
+    expect(isBranchReviewable(idOf(dir))).toBe(true);
+    unmarkBranchReviewable(id);
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+
+  test("`feat/x` and `feat_x` are DISTINCT branches to the store", () => {
+    // The original key collapsed every unsafe character to `_`, mapping these two live branches
+    // onto one record -- so marking one marked the other, and a self-review recorded against one
+    // satisfied the gate on the other. A round-trip test cannot see this: a consistently-wrong key
+    // round-trips perfectly. Only two branches that COLLIDE under the old scheme can.
+    // THE ANCESTRY MUST NOT RESCUE THE TEST. A first version created the two branches as siblings
+    // off main, and it passed even with the collision restored -- because the sha anchor rejected
+    // the borrowed record independently, so the test proved the anchor works, not that the keys
+    // differ. It survived its own mutation and I nearly kept it.
+    //
+    // Making `feat/x` a DESCENDANT of `feat_x` removes that second line of defence: the borrowed
+    // sha IS an ancestor of HEAD, so the anchor says yes and only a distinct key can say no.
+    const { dir } = makeRepo("collide");
+    sh(["checkout", "-qb", "feat_x"], dir);
+    commit(dir, "underscored\n");
+    const underscored = idOf(dir);
+    markBranchReviewable(underscored, sh(["rev-parse", "HEAD"], dir).trim());
+    expect(isBranchReviewable(underscored)).toBe(true);
+
+    sh(["checkout", "-qb", "feat/x"], dir); // branches FROM feat_x, so it descends from that sha
+    commit(dir, "slashed\n");
+
+    expect(isBranchReviewable(idOf(dir))).toBe(false);
+  });
+});

--- a/plugins/itp-hooks/hooks/lib/review-round-state.ts
+++ b/plugins/itp-hooks/hooks/lib/review-round-state.ts
@@ -12,6 +12,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
@@ -82,14 +83,48 @@ export function collectFacts(cwd: string): RepoFacts | null {
   const base = resolveBase(cwd);
   if (base === null) return null;
   try {
+    const root = git(["rev-parse", "--show-toplevel"], cwd).trim();
     const headSha = git(["rev-parse", "HEAD"], cwd).trim();
     // Working tree INCLUDED: `git diff <base>` (no `..HEAD`) spans committed and uncommitted work,
     // so an artifact cannot be satisfied by recording a pass and then editing before pushing.
-    const diffText = git(["diff", base], cwd);
-    const changedPaths = git(["diff", "--name-only", base], cwd)
+    let diffText = git(["diff", base], cwd);
+    const tracked = git(["diff", "--name-only", base], cwd)
       .split("\n")
       .map((s) => s.trim())
       .filter(Boolean);
+
+    // UNTRACKED FILES ARE PART OF THE CHANGE, and `git diff` cannot see them.
+    //
+    // Found by using the gate on itself: recording a self-review for this very commit was REFUSED
+    // because the new test file was not in `git diff --name-only`, so the gate considered a verdict
+    // for it to be a verdict for a file that is not in the diff. The failure was cosmetic; what it
+    // exposed was not. A brand-new file was exempt from the requirement entirely, and because the
+    // S2 diff hash also could not see it, an entire new module could be added AFTER recording a
+    // pass without invalidating the record. New files are precisely where unreviewed code lives.
+    //
+    // `--exclude-standard` honours .gitignore, so build output and caches stay out. `--full-name`
+    // forces repo-root-relative paths to match `git diff --name-only`, which is root-relative
+    // regardless of cwd; without it, running from a subdirectory produced two different spellings
+    // of the same file and the set comparison failed for a reason that had nothing to do with review.
+    const untracked = git(["ls-files", "--others", "--exclude-standard", "--full-name"], cwd)
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    // Hash the CONTENT rather than inlining it: a new file may be binary or large, and all the
+    // artifact needs is a value that changes when the file changes.
+    for (const rel of untracked.toSorted()) {
+      let digest = "unreadable";
+      try {
+        digest = createHash("sha256").update(readFileSync(join(root, rel))).digest("hex");
+      } catch {
+        // Unreadable is still recorded, and recorded DISTINCTLY, so it cannot silently look
+        // identical to a readable file or vanish from the hash.
+      }
+      diffText += `\n--- untracked ${rel} ${digest}\n`;
+    }
+
+    const changedPaths = [...new Set([...tracked, ...untracked])].toSorted();
     return { headSha, baseSha: base, diffText, changedPaths };
   } catch {
     return null;
@@ -100,9 +135,35 @@ export function collectFacts(cwd: string): RepoFacts | null {
 // Stores
 // ---------------------------------------------------------------------------------------------
 
+/**
+ * ONE spelling of the on-disk key, used by BOTH stores.
+ *
+ * They disagreed before: the artifact path sanitised the branch name while the reviewable list
+ * stored it raw, so `feat/x` and `feat_x` were one branch to the artifact store and two to the
+ * reviewable store. `String.replace` with a string pattern also substitutes only the FIRST match,
+ * so a slug containing two slashes was mangled. Both are latent today and neither is a defect
+ * anyone would find by reading the call sites -- which is the argument for having one function.
+ */
+function repoDir(id: RepoIdentity): string {
+  return join(STATE_ROOT, id.slug.replaceAll("/", "__"));
+}
+
+/**
+ * INJECTIVE, which the original was not. Collapsing every unsafe character to `_` maps `feat/x` and
+ * `feat_x` onto one key, so two live branches shared one artifact and one reviewable record -- a
+ * self-review recorded on one silently satisfied the gate on the other. Percent-escaping is
+ * reversible, so distinct branches keep distinct keys, including a branch perversely named
+ * `feat%2Fx` (the `%` is itself escaped).
+ */
+function branchKey(id: RepoIdentity): string {
+  return id.branch.replace(
+    /[^A-Za-z0-9._-]/g,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`,
+  );
+}
+
 function artifactPath(id: RepoIdentity): string {
-  const safeBranch = id.branch.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join(STATE_ROOT, id.slug.replace("/", "__"), `${safeBranch}.json`);
+  return join(repoDir(id), `${branchKey(id)}.json`);
 }
 
 export function readArtifact(id: RepoIdentity): ReviewRoundArtifact | null {
@@ -126,47 +187,108 @@ export function writeArtifact(id: RepoIdentity, artifact: ReviewRoundArtifact): 
 }
 
 /**
- * Branches this gate has watched become reviewable.
+ * Branches this gate has watched become reviewable, each ANCHORED TO THE COMMIT it was shown at.
  *
  * This is how `git push` gating knows a branch is in front of a human WITHOUT asking GitHub. It is
  * populated when the gate ALLOWS a `pr create`/`pr ready`, which is the only moment the transition
  * is observable locally.
  *
- * THE HONEST HOLE, stated rather than hidden: a PR opened outside this gate -- through the web UI,
- * `gh api`, or a session with hooks disabled -- is never recorded, so pushes to it are unmetered.
- * That is a real gap and it is why the gate's message says what it cannot see.
+ * THE ANCHOR IS THE POINT, and the first version did not have one. It stored bare branch NAMES and
+ * had no code path that ever removed one -- no expiry, no TTL, no unmark. The bit therefore
+ * survived the PR merging, the PR closing, the branch being deleted, and the same branch name being
+ * created again months later for unrelated work. A gate whose scope is "only once a review is
+ * pending" was in fact binding "forever, once a review was ever pending, even on a different
+ * branch that happens to share a name".
+ *
+ * Recording the sha and requiring it to still be an ancestor of HEAD fixes all four with one local
+ * predicate. A recreated branch of the same name does not descend from the old sha, so it reads as
+ * not-reviewable; a deleted-and-restored branch likewise. `--undo` is handled separately and
+ * explicitly, because converting back to draft is a real transition rather than a divergence.
+ *
+ * IT MUST STAY LOCAL. `gh pr view --json state` would answer this exactly, and it is precisely the
+ * call this gate cannot make: a PreToolUse hook that times out does not block, so a network probe
+ * resolves to ALLOW whenever GitHub is slow.
+ *
+ * TWO HONEST HOLES, stated rather than hidden. (1) A PR opened outside this gate -- web UI, `gh
+ * api`, or a session with hooks disabled -- is never recorded, so pushes to it are unmetered.
+ * (2) A PR opened through the REVIEW_ROUND_OK override is also never recorded, because the override
+ * path returns `ask` and stops before the mark is written. Marking there was considered and
+ * rejected: `ask` means the operator may still decline, and a mark written for a command that was
+ * then declined would gate every later push to a branch that has no PR at all -- a false positive
+ * with no remedy, which is the failure mode that gets a guard switched off.
  */
-function reviewableePath(id: RepoIdentity): string {
-  return join(STATE_ROOT, id.slug.replace("/", "__"), "reviewable-branches.json");
+export interface ReviewableRecord {
+  readonly branch: string;
+  readonly sha: string;
+  readonly at: string;
 }
 
-export function isBranchReviewable(id: RepoIdentity): boolean {
-  const path = reviewableePath(id);
-  if (!existsSync(path)) return false;
+interface ReviewableStore {
+  readonly schema: 2;
+  readonly branches: ReviewableRecord[];
+}
+
+function reviewablePath(id: RepoIdentity): string {
+  return join(repoDir(id), "reviewable-branches.json");
+}
+
+function readReviewableStore(id: RepoIdentity): ReviewableRecord[] {
+  const path = reviewablePath(id);
+  if (!existsSync(path)) return [];
   try {
-    const list = JSON.parse(readFileSync(path, "utf8"));
-    return Array.isArray(list) && list.includes(id.branch);
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    // A v1 store was a bare string[] with no sha. There is no honest migration -- the commit it was
+    // reviewed at is simply not recorded -- and inventing one (e.g. treating HEAD as the anchor)
+    // would silently re-arm a stale mark. Discard it: the worst case is one unmetered push, which
+    // is strictly better than an un-expirable gate, and the gate re-marks on the next `pr ready`.
+    if (!parsed || !Array.isArray(parsed.branches)) return [];
+    return parsed.branches.filter(
+      (r: unknown): r is ReviewableRecord =>
+        typeof r === "object" &&
+        r !== null &&
+        typeof (r as ReviewableRecord).branch === "string" &&
+        typeof (r as ReviewableRecord).sha === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeReviewableStore(id: RepoIdentity, branches: ReviewableRecord[]): void {
+  const path = reviewablePath(id);
+  mkdirSync(dirname(path), { recursive: true });
+  const store: ReviewableStore = { schema: 2, branches };
+  writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`);
+}
+
+/** True when `sha` is an ancestor of HEAD. False on any git failure -- unknown must not gate. */
+function stillDescendsFrom(sha: string, cwd: string): boolean {
+  try {
+    git(["merge-base", "--is-ancestor", sha, "HEAD"], cwd);
+    return true;
   } catch {
     return false;
   }
 }
 
-export function markBranchReviewable(id: RepoIdentity): void {
-  const path = reviewableePath(id);
-  mkdirSync(dirname(path), { recursive: true });
-  let list: string[] = [];
-  if (existsSync(path)) {
-    try {
-      const parsed = JSON.parse(readFileSync(path, "utf8"));
-      if (Array.isArray(parsed)) list = parsed.filter((x) => typeof x === "string");
-    } catch {
-      list = [];
-    }
-  }
-  if (!list.includes(id.branch)) {
-    list.push(id.branch);
-    writeFileSync(path, `${JSON.stringify(list, null, 2)}\n`);
-  }
+export function isBranchReviewable(id: RepoIdentity): boolean {
+  const record = readReviewableStore(id).find((r) => r.branch === branchKey(id));
+  if (!record) return false;
+  return stillDescendsFrom(record.sha, id.root);
+}
+
+export function markBranchReviewable(id: RepoIdentity, sha: string): void {
+  const key = branchKey(id);
+  const others = readReviewableStore(id).filter((r) => r.branch !== key);
+  writeReviewableStore(id, [...others, { branch: key, sha, at: new Date().toISOString() }]);
+}
+
+/** Drop the mark: the branch has left the review queue (`gh pr ready --undo`). */
+export function unmarkBranchReviewable(id: RepoIdentity): void {
+  const key = branchKey(id);
+  const current = readReviewableStore(id);
+  const remaining = current.filter((r) => r.branch !== key);
+  if (remaining.length !== current.length) writeReviewableStore(id, remaining);
 }
 
 /** Append-only audit of every override, so bypass is countable rather than invisible. */

--- a/plugins/itp-hooks/hooks/pretooluse-review-round-gate.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-review-round-gate.ts
@@ -30,7 +30,17 @@ import {
   markBranchReviewable,
   readArtifact,
   recordOverride,
+  unmarkBranchReviewable,
 } from "./lib/review-round-state.ts";
+
+/**
+ * Passed to `parseStdinOrAllow` so this hook's log lines are attributable.
+ *
+ * It was omitted entirely in the first version, which typechecked as an arity error nobody ran:
+ * `createHookLogger(undefined)` mis-keys every entry this hook writes. Every other PreToolUse hook
+ * in the plugin passes its name.
+ */
+const HOOK_NAME = "REVIEW-ROUND-GATE";
 
 const RECORD_COMMAND = 'bun "$(cc-plugin-root itp-hooks)/hooks/lib/review-round-cli.ts" record';
 
@@ -95,7 +105,13 @@ function inlineBodyMessage(matched: string): string {
 }
 
 async function main(): Promise<void> {
-  const input = await parseStdinOrAllow();
+  // NULL IS A REAL RETURN VALUE, not a formality. `parseStdinOrAllow` returns null when stdin is
+  // absent or unparseable; the first version dereferenced it directly, so a malformed payload threw
+  // and reached the catch-all instead of allowing cleanly. It still failed open, but through the
+  // error path, which both mis-reports a routine condition as a hook fault and makes the genuine
+  // fault count useless. The end-to-end fixtures always fed valid JSON, so nothing could see it.
+  const input = await parseStdinOrAllow(HOOK_NAME);
+  if (input === null) return allow();
   if (input.tool_name !== "Bash") return allow();
 
   const command = String(input.tool_input?.command ?? "");
@@ -113,12 +129,23 @@ async function main(): Promise<void> {
   // block work the gate cannot reason about.
   if (repo === null) return allow();
 
+  // LEAVING the queue is a state transition, not a gated action. It is handled BEFORE the override
+  // check because there is nothing here to override: `--undo` is always allowed, and the only
+  // question is whether the gate notices. Previously it did not -- `--undo` classified as null, so
+  // the branch stayed marked and every push to the re-drafted PR kept demanding a fresh record.
+  if (kind === "pr-undraft") {
+    unmarkBranchReviewable(repo);
+    return allow();
+  }
+
   const reason = overrideReason(command);
   if (reason !== null) {
     recordOverride(repo, kind, reason, command);
     return ask(
       `[REVIEW-ROUND-GATE] Override requested for ${kind}: "${reason}"\n\n` +
-        "Recorded in the override log. Approve to proceed.",
+        "Recorded in the override log. Approve to proceed.\n" +
+        "NOTE: an override does NOT mark this branch reviewable, so later pushes to it are not " +
+        "metered by this gate.",
     );
   }
 
@@ -137,7 +164,10 @@ async function main(): Promise<void> {
 
   // Allowed, and the transition is now observable: remember that this branch is reviewable so
   // subsequent pushes are metered too.
-  if (kind === "pr-ready" || kind === "pr-create") markBranchReviewable(repo);
+  // The mark is ANCHORED to the commit that was shown. A bare branch name could never expire; a
+  // sha can be tested against HEAD later, which is what makes "only while a review is pending"
+  // enforceable without asking GitHub.
+  if (kind === "pr-ready" || kind === "pr-create") markBranchReviewable(repo, facts.headSha);
   return allow();
 }
 


### PR DESCRIPTION
Five defects in the review-round gate merged nine hours ago in #125 — four found by an adversarial survey of my own code, the fifth by running the gate's own CLI on this very commit. All five live in the half #125 shipped with **no tests at all**: the classifier and validator were covered, the state machine was not, which is exactly why none were visible.

Five defects in the gate merged nine hours ago in #125, four of them found by an adversarial survey of my own code and the fifth by running the gate's own CLI on this very commit. All five live in the half that #125 shipped with no tests at all: the classifier and validator were covered, the state machine was not, which is exactly why none of these were visible.

1. THE MARK NEVER EXPIRED. `markBranchReviewable` stored a bare branch NAME and appended; no code path anywhere removed one. No expiry, no TTL, no unmark. The bit therefore survived the PR merging, the PR closing, the branch being deleted, and the same name being created again later for unrelated work. A gate scoped to "only while a review is pending" was in fact binding "forever, once a review was ever pending, even on a different branch sharing a name". The store also lives in ~/.claude/state, not .git, so it outlived re-cloning.

Fixed by anchoring: the record is {branch, sha} and isBranchReviewable additionally requires `git merge-base --is-ancestor <sha> HEAD`. One local predicate covers merge, deletion and name reuse together. It must stay local — `gh pr view --json state` would answer this exactly and is precisely the call this gate cannot make, because a PreToolUse hook that times out does not block.

2. `gh pr ready --undo` DID NOT CLEAR IT. classify() collapsed `--undo` to {kind:null}, indistinguishable from `ls -la`, so the gate had no moment at which to notice the branch had left the queue — while the module's own comment asserted that `--undo` "removes work from the queue". The comment described an intent the code did not implement. It now classifies as `pr-undraft`: still never gated, but observed, and it clears the mark.

3. THE TWO STORES DISAGREED ON A BRANCH NAME. The artifact path sanitised it, the reviewable list stored it raw, and the sanitiser collapsed every unsafe character to `_` — so `feat/x` and `feat_x` were one branch to one store and two to the other, and a self-review recorded on one silently satisfied the gate on the other. Now one injective percent-escaping key, used by both.

4. parseStdinOrAllow WAS CALLED WRONG. No hook-name argument, so every log line this hook wrote was mis-keyed; and its `PreToolUseInput | null` return was dereferenced unchecked, so malformed stdin threw and reached the catch-all instead of allowing cleanly — failing open through the error path, which mis-reports a routine condition as a hook fault. Every other PreToolUse hook in the plugin passes its name. The end-to-end fixtures always fed valid JSON.

5. UNTRACKED FILES WERE INVISIBLE, and this is the one that mattered most. collectFacts used `git diff <base>`, which does not see untracked files, so a brand-new file was exempt from the self-review requirement entirely — and because the S2 diff hash also could not see it, an entire new module could be added AFTER recording a pass while the record stayed valid. New files are precisely where unreviewed code lives.

Found by using the gate on itself: recording a self-review for this commit was REFUSED because the new test file was not in the diff. The refusal was cosmetic; what it exposed was not.

VERIFICATION 16 new lifecycle tests against REAL `git init` repositories, because the fix turns on `git merge-base --is-ancestor` actually behaving like git. Baseline asserted green first (PR #508: a harness without that check fabricated 18/18 kills). It earned its keep immediately — it refused to run when the `--undo` change contradicted an existing assertion, rather than scoring mutations against a red tree. 12 mutations, 0 survivors, restores byte-identical by sha256, post-restore baseline re-checked. Ten are on-target; two are false-positive kills that must stay GREEN, because a guard that fires on legitimate variants is one the next person disables. 1566 tests across the whole plugin, 0 fail. 14/14 end-to-end against the real hook binary, including the new `--undo` clears-the-mark path. validate-plugins.mjs: 41 plugins, 0 errors.

ONE TEST FAILED HONESTLY AND WAS REWRITTEN. The `feat/x` vs `feat_x` case first created the two branches as siblings and PASSED with the collision restored — because the sha anchor rejected the borrowed record independently. It proved the anchor works, not that the keys differ. Making one branch a descendant of the other removes that second line of defence, so only a distinct key can pass. A test that survives its own mutation is decoration; this one nearly shipped as such.

STILL OPEN, deliberately. A PR opened through the REVIEW_ROUND_OK override is never marked reviewable, so its later pushes go unmetered. Marking there was considered and rejected: the override path returns `ask`, the operator may still decline, and a mark written for a declined command would gate every later push to a branch with no PR at all. That hole is now stated in the code and in the override's own message rather than left undocumented.

