### PR TITLE
fix(hooks): a quoted env assignment blinded four guards

### DIFF
--- a/plugins/devops-tools/hooks/posttooluse-1password-pattern-reminder.sh
+++ b/plugins/devops-tools/hooks/posttooluse-1password-pattern-reminder.sh
@@ -94,7 +94,11 @@ COMMAND=$(echo "$PAYLOAD" | jq -r '.tool_input.command // empty' 2>/dev/null) ||
 # Perf note: the anchored regex is O(1) for the common no-match case (most
 # Bash tool calls are NOT op), vs the prior pattern's O(n) scan over the
 # full command body. Win is measurable for long commit messages.
-if ! grep -qE '^([A-Za-z_][A-Za-z0-9_]*=\S*[[:space:]]+)*op([[:space:]]|$)' <<<"$COMMAND"; then
+# A QUOTED ASSIGNMENT VALUE MAY CONTAIN SPACES. `\S*` stops at the first space, so
+# `OP_ACCOUNT="my team" op item get x` did not match and the reminder never fired. Same defect as
+# pretooluse-pr-citation-evidence-guard.ts and the sigpipe detector; this one cannot import the
+# TypeScript helper, so the alternation is spelled out in ERE here.
+if ! grep -qE '^([A-Za-z_][A-Za-z0-9_]*=("[^"]*"|'"'"'[^'"'"']*'"'"'|\S*)[[:space:]]+)*op([[:space:]]|$)' <<<"$COMMAND"; then
     exit 0
 fi
 

--- a/plugins/itp-hooks/hooks/git-worktree-guard-patterns.ts
+++ b/plugins/itp-hooks/hooks/git-worktree-guard-patterns.ts
@@ -81,7 +81,19 @@ function tokenize(segment: string): string[] {
 function stripLeadingEnvAssignments(tokens: string[]): string[] {
   let i = 0;
   while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) {
-    i++;
+    // A QUOTED VALUE SPANS TOKENS, because tokenize() splits on bare whitespace. Without this,
+    // `GH_ORGS="Eon Labs" git checkout -b x` tokenised to ['GH_ORGS="Eon', 'Labs"', 'git', …]:
+    // the first token was consumed as an assignment, the second did not look like one, and the
+    // scan stopped with `Labs"` in the command position — so the guard never saw `git` at all and
+    // the worktree-per-branch policy was silently unenforced. Measured, not theorised.
+    const opened = tokens[i].slice(tokens[i].indexOf("=") + 1);
+    const quote = opened.startsWith('"') ? '"' : opened.startsWith("'") ? "'" : null;
+    if (quote !== null && !opened.slice(1).includes(quote)) {
+      // Consume tokens until the closing quote is found, or the command ends.
+      i += 1;
+      while (i < tokens.length && !tokens[i].includes(quote)) i += 1;
+    }
+    i += 1;
   }
   return tokens.slice(i);
 }

--- a/plugins/itp-hooks/hooks/lib/sigpipe-under-pipefail-detector-iter125.test.ts
+++ b/plugins/itp-hooks/hooks/lib/sigpipe-under-pipefail-detector-iter125.test.ts
@@ -270,3 +270,26 @@ describe("multi-stage pipelines", () => {
     expect(sites[0]?.producer).toBe("producer");
   });
 });
+
+describe("a quoted environment assignment must not hide the reader", () => {
+  // The assignment-stripping prefix used `[^ \t]*`, which stops at the first space — the same
+  // defect as the citation guard's `\S*`, spelled differently, which is why a grep for `\S*`
+  // did not find it. With a quoted value containing a space the strip left `b" head -1` as the
+  // segment, the reader was not recognised, and the site went unreported.
+  it("detects the reader behind an unquoted assignment (the case that always worked)", () => {
+    expect(detect('cat f | FOO=1 head -1\n')).toHaveLength(1);
+  });
+
+  it("detects the reader behind a DOUBLE-quoted assignment containing a space", () => {
+    expect(detect('cat f | FOO="a b" head -1\n')).toHaveLength(1);
+  });
+
+  it("detects the reader behind a SINGLE-quoted assignment containing a space", () => {
+    expect(detect("cat f | FOO='a b' head -1\n")).toHaveLength(1);
+  });
+
+  it("still reports nothing when the reader does not exit early", () => {
+    // False-positive control: the fix must not make the detector fire on safe pipelines.
+    expect(detect('cat f | FOO="a b" cat\n')).toHaveLength(0);
+  });
+});

--- a/plugins/itp-hooks/hooks/lib/sigpipe-under-pipefail-detector-iter125.ts
+++ b/plugins/itp-hooks/hooks/lib/sigpipe-under-pipefail-detector-iter125.ts
@@ -318,7 +318,10 @@ export function detectSigpipeUnderPipefailSites(
       const segment = code
         .slice(p + 1)
         .replace(/^[ \t]+/, "")
-        .replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=[^ \t]*[ \t]+)*/, "");
+        // `[^ \t]*` stopped at the first space, so `FOO="a b" head -1` left `b" head -1` as the
+        // segment and the reader was not recognised. Same defect as the citation guard's `\S*`,
+        // spelled differently — which is why a grep for `\S*` alone did not find it.
+        .replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^ \t]*)[ \t]+)*/, "");
 
       const regexMatch = EARLY_EXITING_READERS.find(([rx]) => rx.test(segment));
       const reader = regexMatch

--- a/plugins/itp-hooks/hooks/pretooluse-git-worktree-guard.test.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-git-worktree-guard.test.ts
@@ -160,3 +160,35 @@ describe("hook — exceptions & escape hatches", () => {
     expectAllow(runHook("ALLOW_BARE_BRANCH=1 git checkout -b f")));
   it("allows non-Bash tool", () => expectAllow(runHook("git checkout -b f", "Write")));
 });
+
+describe("a quoted environment assignment must not blind the guard", () => {
+  // tokenize() splits on bare whitespace, so `GH_ORGS="Eon Labs" git checkout -b x` produced
+  // ['GH_ORGS="Eon', 'Labs"', 'git', …]. The first token was consumed as an assignment, the second
+  // did not look like one, and the scan stopped with `Labs"` in the command position — the guard
+  // never saw `git` and the worktree-per-branch policy went unenforced. Measured, not theorised:
+  // the unquoted `FOO=1` form works either way, which is why no existing case caught it.
+  const bypasses = [
+    'GH_ORGS="Eon Labs" git checkout -b feature',
+    "GH_ORGS='Eon Labs' git checkout -b feature",
+    'A=1 GH_ORGS="Eon Labs" git switch -c feature',
+    'GH_ORGS="Eon Labs" git branch feature',
+  ];
+  for (const command of bypasses) {
+    it(`still blocks: ${command.slice(0, 52)}`, () => {
+      expect(classifyBranchCreation(command).blocked).toBe(true);
+    });
+  }
+
+  it("an unquoted assignment still works (the case that always passed)", () => {
+    expect(classifyBranchCreation("FOO=1 git checkout -b feature").blocked).toBe(true);
+  });
+
+  it("does NOT block a non-branch-creating command behind a quoted assignment", () => {
+    // The consumption loop must not run off the end and swallow the real command.
+    expect(classifyBranchCreation('GH_ORGS="Eon Labs" git status').blocked).toBe(false);
+  });
+
+  it("an unterminated quote does not hang or swallow everything", () => {
+    expect(() => classifyBranchCreation('GH_ORGS="unterminated git checkout -b x')).not.toThrow();
+  });
+});

--- a/plugins/itp-hooks/hooks/pretooluse-pr-citation-evidence-guard.test.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-pr-citation-evidence-guard.test.ts
@@ -25,6 +25,14 @@ describe("surface scoping", () => {
     ["gh api repos/o/r/pulls/12/comments -f body='x'", true],
     ["gh api repos/o/r/pulls/12/reviews -f body='x'", true],
     ["gh api repos/o/r/issues/12/comments -f body='x'", true],
+    // A QUOTED assignment value containing a SPACE. `\S*` stopped at the first space, so these
+    // matched no command position and the guard skipped the citation check entirely — before a
+    // body was even collected. Reproduced end-to-end: the identical body was DENIED unquoted and
+    // ALLOWED with the quoted prefix. The unquoted case two lines down passes either way, which is
+    // exactly why it never caught this.
+    ['GH_ORGS="Eon Labs" gh pr comment 12 --body \'x\'', true],
+    ["GH_ORGS='Eon Labs' gh pr review 12 -b 'x'", true],
+    ['env GH_ORGS="Eon Labs" sudo gh pr comment 12 --body \'x\'', true],
     // Real command positions: after a separator, and behind env assignments or a wrapper.
     ["cd /tmp && gh pr comment 12 --body 'x'", true],
     ["set -e; gh pr review 12 -b 'x'", true],

--- a/plugins/itp-hooks/hooks/pretooluse-pr-citation-evidence-guard.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-pr-citation-evidence-guard.ts
@@ -83,7 +83,12 @@ const CITATION_OK = {
  */
 // Assignments and wrappers INTERLEAVE — `GH_TOKEN=x gh …` and `env GH_HOST=y gh …` are both real,
 // and a fixed order matched only the first. Caught by this file's own table on the second run.
-const COMMAND_POSITION = String.raw`(?:^|[\n;&|(){}]|&&|\|\|)\s*(?:(?:sudo|env|command|time)\s+|[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*`;
+// AN ASSIGNMENT VALUE MAY BE QUOTED AND MAY CONTAIN SPACES. `\S*` stops at the first space, so
+// `GH_ORGS="Eon Labs" gh pr comment …` matched no command position at all and this guard silently
+// ALLOWED it — the citation requirement was skipped entirely, before a body was even collected.
+// Reproduced directly: the identical body is DENIED unquoted and ALLOWED with the quoted prefix.
+// `FOO=bar` works either way, which is why every existing test case missed it.
+const COMMAND_POSITION = String.raw`(?:^|[\n;&|(){}]|&&|\|\|)\s*(?:(?:sudo|env|command|time)\s+|[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)*`;
 
 const ghCommand = (rest: string) => new RegExp(`${COMMAND_POSITION}gh\\s+${rest}`, "i");
 


### PR DESCRIPTION
`GH_ORGS="Eon Labs" gh pr comment …` matched no command position, so the citation guard silently **allowed** it — the check was skipped entirely, before a body was even collected. Flagged when the same defect defeated the review-round gate in #125; this fixes it at the source and at every other site of the same class.

## Reproduced, not inferred

The identical PR-review body is **DENIED** as `gh pr comment 12 --body '…'` and **ALLOWED** as `GH_ORGS="Eon Labs" gh pr comment 12 --body '…'`. An unquoted `FOO=bar` works either way, which is exactly why every existing test case missed it.

## Four sites, and the count came from widening the grep

Searching for `\S*` found two. The same defect is spelled three different ways:

| site | value pattern | severity |
| --- | --- | --- |
| `pretooluse-pr-citation-evidence-guard.ts:86` | `=\S*` | **deny bypass** |
| `git-worktree-guard-patterns.ts:83` | token-based | **deny bypass** |
| `lib/sigpipe-under-pipefail-detector-iter125.ts:321` | `=[^ \t]*` | missed advisory |
| `devops-tools/…/1password-pattern-reminder.sh:97` | `=\S*` (bash ERE) | missed advisory |

Two further sites already had the correct idiom — `headless-claude-p-patterns.ts` and `review-round-artifact.ts`. Five hand-rolled command-position peelers now agree on the value pattern.

## The worktree guard is the worst of them, and it was not on the original list

Its tokenizer splits on bare whitespace, so `GH_ORGS="Eon Labs" git checkout -b x` became `['GH_ORGS="Eon', 'Labs"', 'git', …]`. The first token was consumed as an assignment, the second did not look like one, and the scan stopped with `Labs"` sitting in the command position — so the guard **never saw `git` at all**, and worktree-per-branch, a CRITICAL policy, went unenforced for any quoted assignment containing a space.

Confirmed by running its real tokenizer rather than reading it:

```
SEES git   FOO=1 git checkout -b feature            -> first token: "git"
BLIND      GH_ORGS="Eon Labs" git checkout -b …     -> first token: "Labs\""
```

## No shared helper in this commit, deliberately

The right target is one `lib/` export consumed by all of them. But the worktree tokenizer and the sigpipe strip want a quote-aware *strip* rather than a regex prefix, and the bash reminder cannot import TypeScript at all — four call-site refactors across two plugins with opposite failure directions (deny-bypass vs missed-reminder), which the suites were too thin to backstop until this commit lands.

Also unchanged: the citation guard matches `gh` with no path prefix, so `/opt/homebrew/bin/gh` still evades it. A real bypass, but a genuine behaviour widening that deserves its own change and its own false-positive rows.

## Verification

**3 mutations, 0 survivors**, restores byte-identical by `sha256`, baseline asserted green first and re-checked after.

**C3 survived on the first run.** The sigpipe fix had no test at all, which for a regression guard is indistinguishable from not having fixed it — nothing would report the regression. Four cases were added, including a false-positive control, and it now dies.

Every site ships positive cases *and* controls that must stay green: `git status` behind a quoted assignment must not block, an unterminated quote must not run off the end of the command, and `echo op` / `open something` must still not trigger the 1Password reminder.

1580 tests across the plugin, 0 fail. `validate-plugins.mjs`: 41 plugins, 0 errors. `bash -n` clean on the modified shell script.
