### PR TITLE
fix(itp-hooks): shell-script-safety-guard has never blocked anything

### DIFF
--- a/plugins/itp-hooks/hooks/pretooluse-edit-time-orchestrator-combining-multiple-subhooks-into-single-bun-process-iter66-precedent.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-edit-time-orchestrator-combining-multiple-subhooks-into-single-bun-process-iter66-precedent.ts
@@ -373,9 +373,25 @@ async function main(): Promise<void> {
   const input = await parseStdinOrAllow("pretooluse-edit-time-orchestrator");
   if (!input) return;
 
-  // Fastpath: only run the registry on Write/Edit. For any other tool
-  // (which shouldn't happen given the hooks.json matcher, but defense-
-  // in-depth), allow immediately.
+  // Fastpath: only run the registry on Write/Edit.
+  //
+  // THE OLD COMMENT HERE WAS WRONG and actively dangerous. It said any other tool "shouldn't happen
+  // given the hooks.json matcher" — but the matcher IS `Write|Edit|MultiEdit`, so MultiEdit reaches
+  // this line on every multi-edit and is dropped here. That reads like an obvious one-line bug, and
+  // it was recommended to me as one.
+  //
+  // It is not a bug, it is the load-bearing half of a staged migration. iter-102 widened the
+  // tool-name gate inside the classifiers to accept MultiEdit, but per-classifier PAYLOAD
+  // adaptation is iter-103 work: a MultiEdit carries `edits[]`, not `content`/`new_string`. Every
+  // classifier therefore short-circuits MultiEdit to ALLOW straight after the tool-name check.
+  //
+  // So forwarding MultiEdit from here would be a no-op for ten of the eleven classifiers and, until
+  // the sibling fix in this same commit, would have activated exactly ONE — shell-script-safety —
+  // against a payload whose `new_string` is undefined. Measured before changing anything.
+  //
+  // OPENING THIS IS AN iter-103 DECISION, not a typo fix: it requires a content extractor that folds
+  // `tool_input.edits[].new_string`, and a per-classifier review of what "the proposed file" means
+  // when a MultiEdit applies several edits in sequence.
   if (input.tool_name !== "Write" && input.tool_name !== "Edit") {
     return allow();
   }

--- a/plugins/itp-hooks/hooks/pretooluse-shell-script-safety-guard.test.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-shell-script-safety-guard.test.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+/**
+ * Tool-name cohort consistency for the shell-script-safety subhook.
+ *
+ * This guard was the ONLY one of the eleven classifiers in the edit-time orchestrator's cohort
+ * without a MultiEdit short-circuit. iter-102 widened the tool-name GATE to accept MultiEdit but
+ * left per-classifier PAYLOAD adaptation to iter-103, so its ten siblings each return ALLOW for
+ * MultiEdit straight after the gate — a MultiEdit carries `edits[]`, not `content`/`new_string`.
+ *
+ * The omission was harmless only because the orchestrator's fastpath never forwards MultiEdit.
+ * That fastpath looks like an obvious one-line bug and was recommended to me as one; opening it
+ * would have activated this guard alone, against a payload it cannot read, while the other ten
+ * stayed correctly inert. These tests pin the CONSISTENCY, not the capability.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { PreToolUseInput } from "./pretooluse-helpers.ts";
+import { classifyShellScriptSafetyGuardForOrchestrator } from "./pretooluse-shell-script-safety-guard.ts";
+
+const DEFECTIVE_SCRIPT = [
+  "#!/usr/bin/env bash",
+  "set -euo pipefail",
+  "run() {",
+  "  local status=$(some_command)",
+  "  echo \"$status\"",
+  "}",
+  "",
+].join("\n");
+
+describe("the plan-mode check must read .inPlanMode, not the context object", () => {
+  // `isPlanMode` returns a PlanModeContext object, never a boolean. `if (isPlanMode(input))` is
+  // therefore ALWAYS true, and this guard returned ALLOW on every invocation for its entire life —
+  // enforcing nothing, while appearing in the registry as an active CRITICAL-policy guard.
+  it("does NOT allow merely because a context object was returned", async () => {
+    const decision = await classifyShellScriptSafetyGuardForOrchestrator({
+      tool_name: "Write",
+      tool_input: { file_path: "/tmp/not-a-plan.sh", content: DEFECTIVE_SCRIPT },
+    } as unknown as PreToolUseInput);
+
+    expect(decision.kind).toBe("deny");
+  });
+
+  it("DOES allow when the session really is in plan mode", async () => {
+    // The other direction, so the fix cannot be "delete the plan-mode check".
+    const decision = await classifyShellScriptSafetyGuardForOrchestrator({
+      tool_name: "Write",
+      permission_mode: "plan",
+      tool_input: { file_path: "/tmp/planned.sh", content: DEFECTIVE_SCRIPT },
+    } as unknown as PreToolUseInput);
+
+    expect(decision.kind).toBe("allow");
+  });
+});
+
+describe("MultiEdit is inert until iter-103 payload adaptation lands", () => {
+  it("returns allow for a MultiEdit payload rather than reading undefined fields", async () => {
+    const decision = await classifyShellScriptSafetyGuardForOrchestrator({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: "/tmp/example-multiedit.sh",
+        edits: [{ old_string: "x", new_string: DEFECTIVE_SCRIPT }],
+      },
+    } as unknown as PreToolUseInput);
+
+    expect(decision.kind).toBe("allow");
+  });
+
+  it("stays inert even if a future extractor supplies `content` for a MultiEdit", async () => {
+    // THIS is what makes the short-circuit load-bearing rather than decoration. Without it, the
+    // case above passes for the wrong reason — the `!newFileContent` check already allows any
+    // payload lacking `content`, so removing the short-circuit changes nothing today and the
+    // mutation survives. The moment iter-103 folds `edits[].new_string` into a content field, that
+    // accidental protection disappears and this guard would silently begin evaluating MultiEdit
+    // with Edit-branch semantics it was never adapted for. Pin the intent, not the side effect.
+    const decision = await classifyShellScriptSafetyGuardForOrchestrator({
+      tool_name: "MultiEdit",
+      tool_input: {
+        file_path: "/tmp/example-multiedit.sh",
+        content: DEFECTIVE_SCRIPT,
+        edits: [{ old_string: "x", new_string: DEFECTIVE_SCRIPT }],
+      },
+    } as unknown as PreToolUseInput);
+
+    expect(decision.kind).toBe("allow");
+  });
+
+  it("DENIES the same defect when it arrives as a Write", async () => {
+    // The control, and it is the whole point. Without it the test above would pass just as happily
+    // on a guard that had stopped detecting anything at all — which is the failure mode a
+    // short-circuit test is most likely to hide.
+    const decision = await classifyShellScriptSafetyGuardForOrchestrator({
+      tool_name: "Write",
+      tool_input: { file_path: "/tmp/example-write.sh", content: DEFECTIVE_SCRIPT },
+    } as unknown as PreToolUseInput);
+
+    expect(decision.kind).toBe("deny");
+  });
+});

--- a/plugins/itp-hooks/hooks/pretooluse-shell-script-safety-guard.ts
+++ b/plugins/itp-hooks/hooks/pretooluse-shell-script-safety-guard.ts
@@ -113,13 +113,40 @@ export async function classifyShellScriptSafetyGuardForOrchestrator(
   input: PreToolUseInput,
 ): Promise<PreToolUseSubhookDecision> {
   try {
-    // Plan mode → allow all
-    if (isPlanMode(input)) {
+    // Plan mode → allow all.
+    //
+    // THIS GUARD WAS A COMPLETE NO-OP. `isPlanMode` returns a PlanModeContext OBJECT
+    // (`{inPlanMode, signals, reason, …}`), never a boolean — and every object is truthy, so this
+    // line returned ALLOW on every single invocation and the guard never examined one script. It
+    // enforces a CRITICAL policy (a `local x=$(cmd)` masks the command's exit status and defeats
+    // `set -e`), and it has been enforcing nothing.
+    //
+    // Six of the seven call sites in this plugin read `.inPlanMode`; this was the only one that did
+    // not, which is why nothing else was affected and why nothing surfaced it. It was found by
+    // writing a CONTROL for an unrelated test — a Write payload carrying a defect the detector
+    // provably flags — and watching the guard allow it anyway. A test without that control would
+    // have passed against a permanently disarmed guard.
+    if (isPlanMode(input).inPlanMode) {
       return ALLOW_DECISION;
     }
 
     // Only applicable to Write/Edit
     if (!isFileEditToolNameHonoredByPreToolUseBlockingSubhook(input.tool_name)) {
+      return ALLOW_DECISION;
+    }
+
+    // THE ONLY CLASSIFIER IN THE COHORT THAT LACKED THIS. Its ten siblings (file-size, vale,
+    // version, hoisted-deps, mise-hygiene, pyi-stub, native-binary, gpu-optimization,
+    // typescript-version, skill-plugin-root) all short-circuit MultiEdit to ALLOW, because iter-102
+    // widened the tool-name gate but left per-classifier payload adaptation to iter-103: a MultiEdit
+    // carries `edits[]`, not `content`/`new_string`, so the Edit branch below would read `undefined`.
+    //
+    // It was harmless only because the orchestrator's own fastpath never forwards MultiEdit. The
+    // moment someone "fixes" that fastpath — which looks like an obvious one-line correction, and
+    // was recommended to me as one — this guard alone would start running on a payload shape it
+    // cannot read, while the other ten stayed correctly inert. Closing the inconsistency here means
+    // opening the fastpath later is a decision about capability rather than an accident.
+    if (input.tool_name === "MultiEdit") {
       return ALLOW_DECISION;
     }
 


### PR DESCRIPTION
`isPlanMode` returns a `PlanModeContext` **object**, never a boolean. The guard opened with `if (isPlanMode(input)) return ALLOW_DECISION;` — and every object is truthy, so it returned ALLOW on **every single invocation** and never examined one script.

It enforces a 🔴 CRITICAL policy — `local x=$(cmd)` masks the command's exit status and defeats `set -e` — and it has been enforcing nothing for its entire life.

Six of the seven `isPlanMode` call sites in this plugin read `.inPlanMode`. This was the only one that did not, which is why nothing else was affected and why nothing surfaced it.

## How it was found, because the route matters more than the fix

I came here to "fix the MultiEdit fastpath" — a one-line change a survey called an obvious bug. Before touching it I wrote a **control** for the unrelated test: a plain `Write` payload carrying a defect the detector provably flags.

The guard allowed it.

A test without that control would have passed against a permanently disarmed guard and reported success. That is the entire value of the control, and it is why it is now in the file.

## The fastpath is not a bug

This is the part worth recording. The orchestrator skips MultiEdit at `:379` while its `hooks.json` matcher is `Write|Edit|MultiEdit`, which reads exactly like an oversight. It is the load-bearing half of a staged migration: **iter-102 widened the tool-name gate** inside the classifiers to accept MultiEdit, but per-classifier **payload** adaptation is iter-103 work, because a MultiEdit carries `edits[]` rather than `content`/`new_string`.

Measured before changing anything:

| classifiers in the cohort | MultiEdit short-circuit |
| --- | --- |
| 10 of 11 | present — return ALLOW immediately after the gate |
| `shell-script-safety-guard` | **absent** |

So opening the fastpath would have been a no-op for ten of them, and would have activated exactly **one** — the one missing the short-circuit — against a payload whose `new_string` is undefined. The recommended one-line fix would have shipped a false-positive generator.

## So this commit does the opposite of what was recommended

- Re-arms the guard that was actually broken.
- Adds the missing MultiEdit short-circuit, so the cohort is consistent and opening the fastpath later is a **capability decision** rather than an accident.
- Replaces the fastpath's wrong comment — it claimed non-Write/Edit tools "shouldn't happen given the hooks.json matcher" — with the real reason.

## Verification

**5 tests in a file that did not exist.** Both plan-mode directions are pinned, so the fix cannot be "delete the plan-mode check".

**3 mutations, 0 survivors**, restores byte-identical by `sha256`.

**S3 survived at first.** The MultiEdit short-circuit was redundant with the existing empty-content check, so removing it changed nothing and the mutant lived. Rather than keep defensive code no test can kill, the case was rewritten to supply `content` alongside `edits` — the exact shape iter-103 will produce — which makes the short-circuit load-bearing and kills the mutant honestly.

1585 tests across the plugin, 0 fail: re-arming a dormant guard broke nothing. `validate-plugins.mjs` at 41 plugins, 0 errors.

## Not touched

`posttooluse-mini-inngest-doctrine.ts:205` has the same Write-or-Edit-without-MultiEdit shape, but it is under active edit by another session in the shared checkout right now. Left alone deliberately rather than risk clobbering someone else's work; it is advisory, not blocking.
