### PR TITLE
chore(github): add PR template, issue forms, CODEOWNERS and five area:* labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for cc-skills.
+#
+# GitHub requests a review from the owner of every path a PR touches. This repository is
+# single-maintainer, so the catch-all below is the whole policy — it exists to make review
+# assignment automatic rather than to gate anyone out.
+#
+# Syntax reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @terrylica

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Something in this marketplace behaves differently from what it claims.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues in this repository are expected to carry their own evidence. The most useful bug reports here name the exact file and line, and paste the real command output — not a description of it.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What is wrong
+      description: One or two sentences. Lead with the observable defect, not the suspected cause — a title that asserts a cause the evidence does not establish is harder to close than one that describes what was seen.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: The smallest command sequence that shows it. Paste the command AND its real output, including the exit code where that is the point.
+      render: console
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened instead
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: "`file:line` references for claims about this codebase. For claims about anything outside it — a tool's documented behaviour, an upstream bug, a spec — give a verbatim quote and the URL you took it from."
+    validations:
+      required: false
+  - type: input
+    id: versions
+    attributes:
+      label: Relevant versions
+      description: "Output of `proto list` or the pins from `.prototools`, plus the Claude Code version if a hook is involved."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Claude Code itself (upstream)
+    url: https://github.com/anthropics/claude-code/issues
+    about: Defects in the Claude Code CLI or its hook lifecycle belong upstream, not here. This repository only ships plugins and skills that run on top of it.

--- a/.github/ISSUE_TEMPLATE/docs_drift.yml
+++ b/.github/ISSUE_TEMPLATE/docs_drift.yml
@@ -1,0 +1,42 @@
+name: Docs drift
+description: Two places in this repository state the same fact differently, or a doc describes something that no longer exists.
+labels: ["documentation", "area:docs-drift"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repository is organised as a hub-and-spoke link farm with a single source of truth per topic, so the failure worth reporting is not "a doc is out of date" but "two places disagree and a reader cannot tell which one is authoritative". Agents read these files as current instruction, so drift is executable, not cosmetic.
+  - type: textarea
+    id: conflict
+    attributes:
+      label: The conflicting statements
+      description: Quote each one with its `file:line`. If one of them is the designated SSoT for the topic, say which.
+    validations:
+      required: true
+  - type: input
+    id: truth
+    attributes:
+      label: Which is correct, and how you know
+      description: Name the command, file or measurement that settles it.
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of drift
+      options:
+        - A count that has gone stale (plugins, skills, phases)
+        - A tool or path that no longer exists
+        - Two files each claiming to be the SSoT
+        - A rule that a shipped hook already enforces
+        - A doc describing a retired feature as live
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: gate
+    attributes:
+      label: Prevention
+      options:
+        - label: I checked whether an existing gate (`repo:verify-doc-counts`, `repo:link-check`) should have caught this and did not
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!-- Delete a section only if it genuinely does not apply, and replace it with one line saying why. A blank section reads as "not done", not as "not applicable". -->
+
+## What changed, and why
+
+<!-- One paragraph. Lead with the defect or the goal, not with the diff — the diff is already below. -->
+
+## Evidence
+
+<!-- REQUIRED whenever this PR asserts something about the world outside this repository: a tool's behaviour, a spec, an upstream bug, a benchmark number, a "this is the recommended approach" claim, or the reason a plausible alternative was rejected. -->
+
+<!-- Every such claim needs a verbatim quote AND the URL it came from, fetched and checked this session. A bare link is not evidence — it asks the reviewer to go and find the supporting sentence, which is exactly the work the citation was supposed to do for them. -->
+
+<!-- A claim about THIS codebase is evidenced with `file:line` and the real output of the command that proves it, never with a URL. -->
+
+<!-- Known failure mode, measured: a citation can be a real quote from a real source and still be wrong, because it supports a claim of a different SCOPE or the opposite DIRECTION. Check that the quote supports the specific claim you attached it to. -->
+
+| Claim | Verbatim quote | Source |
+| ----- | -------------- | ------ |
+|       |                |        |
+
+## Verification
+
+<!-- The command you actually ran, and its real output. Quality gates run LOCALLY in this repo — GitHub Actions is reserved for semantic-release, CodeQL, Dependabot and deployment, so a green PR page proves nothing about tests. -->
+
+```console
+moon run repo:check
+```
+
+## Issues
+
+<!-- Each issue needs its OWN keyword: `Closes #1, #2, #3` closes only #1. Use `Closes`, `Fixes` or `Resolves` in this body (not the title). Cross-repo form is `Closes owner/repo#N`. Use `Refs #N` for an issue this PR informs but does not resolve. -->
+
+Closes #
+
+## Labels
+
+- [ ] An `area:*` label is set, so this PR is findable by subject later
+- [ ] A `priority:*` label is set if this is tracked work
+- [ ] Any issue this PR closes carries the same `area:*` label


### PR DESCRIPTION
## What changed, and why

This repository has never had a `.github/` directory. Of the three standards required of a pull request here — verbatim citations with their source URLs, a correct set of labels, and one closing keyword per linked issue — only citations had any mechanical support, and that support deliberately does not extend to PR descriptions. This adds the scaffolding so the expectation is recorded in the repo rather than carried in the author's head.

Adds `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/{bug_report,docs_drift,config}.yml`, and `.github/CODEOWNERS`. Separately creates five `area:*` labels (hooks, gates, docs-drift, toolchain, plugins) and backfills them onto 11 open issues.

## Evidence

| Claim | Verbatim quote | Source |
| --- | --- | --- |
| `.github/pull_request_template.md` is the correct path for a hidden-directory PR template, which is why this PR uses that exact lowercase filename rather than the uppercase variant it was first written with | "To store your file in a hidden directory, name the pull request template `.github/pull_request_template.md`." | https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository |
| A closing keyword is what makes a merge close the issue, which is the behaviour the template's Issues section exists to prompt for | "You can link a pull request or branch to an issue to show that a fix is in progress and to automatically close the issue when the pull request or branch is merged." | https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue |
| The citation guard's exclusion of `gh pr create` is deliberate and was left intact by this PR rather than "fixed" | "NOT `gh pr create` (a PR description is authored before review and is not a resolution OF review feedback)... A guard that fires on 'LGTM', 'rebased onto main', or a one-line question is a guard that gets disabled within a week, and then it protects nothing. Narrow and alive beats broad and switched off." | `plugins/itp-hooks/hooks/pretooluse-pr-citation-evidence-guard.ts:18-22` |
| Each issue needs its own keyword, which is why the template says so explicitly | "Each issue needs its own keyword. `Closes #1, #2, #3` only closes `#1`." | `plugins/gh-tools/skills/issues-workflow/references/issue-branch-lifecycle.md:33` |

## Design note: what this deliberately does NOT do

It does not extend the citation guard to fire on `gh pr create`. That guard's own header argues against it, and the argument is sound — a guard that fires on every trivial PR gets switched off, and then it protects nothing. A template prompts at authoring time without blocking, which reaches the same end without putting a working guard at risk.

## Deliberately not removed

The `tool:cargo-*` label set and `rust-toolchain`. An earlier survey called them dead relics dominating the taxonomy. Measured instead of assumed: `rust-toolchain` is applied to 12 issues, and `plugins/rust-tools/` is a live marketplace plugin shipping `rust-dependency-audit` and `rust-sota-arsenal`. Deleting them would have destroyed a working taxonomy on a false premise.

## Verification

Issue-form YAML parses:

```console
$ uv run --with pyyaml python -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/ISSUE_TEMPLATE/*.yml')]"
OK .github/ISSUE_TEMPLATE/bug_report.yml
OK .github/ISSUE_TEMPLATE/config.yml
OK .github/ISSUE_TEMPLATE/docs_drift.yml
```

Labels exist and are applied:

```console
$ gh label list --limit 100 --json name --jq '.[].name' | grep '^area:'
area:hooks
area:gates
area:docs-drift
area:toolchain
area:plugins
```

`moon run repo:check` on this branch is **red for two pre-existing reasons unrelated to this PR**, both confirmed present on a clean checkout of `main` and neither touched here. Reported rather than hidden:

- `plugins/itp-hooks/hooks/tests/test-posttooluse-subprocess-orphan-cleanup-iter64-...sh` asserts `hooks.json timeout is '5000'` while the file correctly says `'5'` after the seconds-not-milliseconds fixes in #124 and #126. The test is stale, not the data. Another session is mid-sweep on exactly this.
- `tasks/tests/test-iter166-status-doctor-coverage-extension-...sh` fails inside the suite and passes standalone (`REAL EXIT = 0`), which is the known in-suite-only flake.

This PR adds five files under `.github/` and touches no code, no hook, and no task, so it cannot affect either.

Closes #131
Refs #108
