### PR TITLE
docs: retire four rules whose stated reasons no longer hold, keeping the rules that are still right

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,19 +406,21 @@ bun scripts/validate-plugins.mjs --fix
 
 Understanding the architectural hierarchy:
 
-| Term          | Definition                                                                                    | Location             | Example             |
-| ------------- | --------------------------------------------------------------------------------------------- | -------------------- | ------------------- |
-| **Plugin**    | Marketplace-installable container with metadata, commands, and optional bundled skills        | `~/.claude/plugins/` | `itp`, `gh-tools`   |
-| **Skill**     | Executable agent with SKILL.md frontmatter; can be standalone or bundled within a plugin      | `~/.claude/skills/`  | `pypi-doppler`      |
-| **Command**   | Slash command (`/plugin:command`) defined in `.md` file within plugin's `commands/` directory | Plugin's `commands/` | `/itp:setup`        |
-| **Reference** | Supporting documentation in `references/` directory; not directly executable                  | `references/`        | `error-handling.md` |
+| Term          | Definition                                                                                    | Location                                                                                                                                                            | Example             |
+| ------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **Plugin**    | Marketplace-installable container with metadata, commands, and optional bundled skills        | `~/.claude/plugins/`                                                                                                                                                | `itp`, `gh-tools`   |
+| **Skill**     | Executable agent with SKILL.md frontmatter; can be standalone or bundled within a plugin      | Plugin's `skills/` (installed at `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/`); `~/.claude/skills/` is for hand-authored personal skills only | `pypi-doppler`      |
+| **Command**   | Slash command (`/plugin:command`) defined in `.md` file within plugin's `commands/` directory | Plugin's `commands/`                                                                                                                                                | `/itp:setup`        |
+| **Reference** | Supporting documentation in `references/` directory; not directly executable                  | `references/`                                                                                                                                                       | `error-handling.md` |
 
 **Hierarchy**:
 
 ```
 Plugin (Container)
 ├── commands/           → Slash commands (/plugin:command)
-├── skills/             → Bundled skills (copied to ~/.claude/skills/ on install)
+├── skills/             → Bundled skills (installed under the plugin's own versioned
+│                         cache dir, NOT copied to ~/.claude/skills/ — resolve with
+│                         `cc-plugin-root <plugin>`)
 │   └── skill-name/
 │       ├── SKILL.md    → Skill definition (frontmatter + instructions)
 │       ├── scripts/    → Executable helpers

--- a/plugins/CLAUDE.md
+++ b/plugins/CLAUDE.md
@@ -58,25 +58,31 @@ plugins/my-plugin/
 | Repo docs (ADRs)     | Repo-root (`/docs/...`) | `[ADR](/docs/adr/file.md)`       |
 | External resources   | Full URL                | `[Docs](https://example.com)`    |
 
-**Why**: Skill files are installed to `~/.claude/skills/`. Relative paths work there; absolute paths don't.
+**Why**: A plugin's skills are installed under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/`, and the **version segment changes on every release** — so any absolute path a skill hardcodes is stale by the next update. Relative links resolve against the skill's own directory wherever that lands.
+
+> **Corrected 2026-09-05.** This used to read "Skill files are installed to `~/.claude/skills/`". That directory does exist, but it holds only hand-authored personal skills — **no marketplace plugin ships anything there**. Measured: `cc-plugin-root gh-tools` → `/Users/terryli/.claude/plugins/cache/cc-skills/gh-tools/30.0.0`, while the same cache dir also retains seven orphaned versions (`29.0.0` … `30.1.0`). That is exactly why `scripts/cc-plugin-root` reads `installed_plugins.json` instead of globbing. The **rule is unchanged** — use relative links — only the reason was wrong.
 
 ## Shell Compatibility
 
-Claude Code's Bash tool may run through zsh on macOS. Wrap bash-specific syntax:
+Claude Code's Bash tool runs **zsh** on macOS (measured 2026-09-05: `$ZSH_VERSION` = `5.9`). Wrap only syntax zsh genuinely does not implement — bash-only parameter expansion (`${var,,}`, `${var^^}`, `${var@Q}`), `mapfile`/`readarray`, `declare -n`, and code that assumes 0-indexed arrays:
 
 ```bash
-# Multi-line bash scripts
-/usr/bin/env bash << 'SCRIPT_EOF'
-if [[ -f "$FILE" ]]; then
-    echo "Found"
-fi
-SCRIPT_EOF
-
-# Single-line commands
-/usr/bin/env bash -c 'VAR=$(command) && echo $VAR'
+# Genuinely bash-only. Unwrapped, zsh answers: (eval):1: bad substitution
+/usr/bin/env bash -c 'V=ABC; echo "${V,,}"'
 ```
 
-**Reference**: [Shell Portability ADR](/docs/adr/2025-12-06-shell-command-portability-zsh.md)
+**Superseded 2026-09-05 — command substitution does NOT need a wrapper.** The [Shell Portability ADR](/docs/adr/2025-12-06-shell-command-portability-zsh.md) recorded the root cause as `VAR=$(cmd) another-cmd` failing in zsh's eval with ``(eval):1: parse error near `('``, and this section accordingly told authors to wrap every `$(...)`. That failure **does not reproduce** on the current Bash tool. Re-measured verbatim, unwrapped:
+
+```
+$ FOO=$(echo bar) env | grep '^FOO='
+FOO=bar
+$ if [[ -f /etc/hosts ]]; then echo "ok"; fi
+ok
+$ VAR=$(echo hello) && echo "got $VAR"
+got hello
+```
+
+Prefix assignment, `$(...)` and `[[ ]]` are all native zsh and need no wrapper — and note the ADR's own two examples were never bash-specific in the first place (`[[ ]]` is a zsh builtin, and `VAR=$(cmd) && ...` is plain assignment, not the prefix-assignment form the ADR blamed). Keep the ADR: it is the dated record of the 2025-12-06 decision and its 97-file sweep. But its blanket "wrap all command substitution" conclusion is retired — wrap for real bash-only syntax, nothing more.
 
 ## Validation
 

--- a/plugins/claude-tts-companion/Sources/CompanionCore/Config.swift
+++ b/plugins/claude-tts-companion/Sources/CompanionCore/Config.swift
@@ -97,7 +97,8 @@ public enum Config {
     static let miniMaxBaseURL = "https://api.minimax.io/anthropic"
 
     /// MiniMax model identifier. Dynamically resolved from the SSoT
-    /// (`MINIMAX_MODEL` env, set by `~/.config/mise/config.toml`) so the model
+    /// (`MINIMAX_MODEL` env, exported by `~/.claude/tools/toolchain/path.sh` since
+    /// 2026-08-21, when mise was retired) so the model
     /// in use always tracks the SSoT and no prior version is ever pinned in
     /// code. Falls back to the current GA model only when the env is unset.
     static let miniMaxModel: String = {

--- a/plugins/devops-tools/CLAUDE.md
+++ b/plugins/devops-tools/CLAUDE.md
@@ -39,10 +39,10 @@ op item get "Item" --vault "Claude Automation" --reveal
 
 ## Self-Hosted Services
 
-Services run on two GPU workstations: **gpu-host-1** (RTX 4090) for primary compute, **gpu-host-2** (RTX 2080 Ti) for secondary workloads. Access via Tailscale primary path or legacy ZeroTier fallback.
+Services run on two GPU workstations: **gpu-host-1** (RTX 4090) for primary compute, **gpu-host-2** (RTX 2080 Ti) for secondary workloads. Access via Tailscale (primary) with Cloudflare Access SSH as the fallback — see the SSoT, [ssh-tunnel-companion/CLAUDE.md](../ssh-tunnel-companion/CLAUDE.md). **ZeroTier is gone** (removed 2026-04-06, macOS kernel-extension fragility); this line advertised it as a "legacy fallback" until 2026-09-05, contradicting its own linked SSoT.
 
-| Service    | Host     | Port | Tunnel          | Skill                                             |
-| ---------- | -------- | ---- | --------------- | ------------------------------------------------- |
+| Service    | Host       | Port | Tunnel          | Skill                                             |
+| ---------- | ---------- | ---- | --------------- | ------------------------------------------------- |
 | ClickHouse | gpu-host-1 | 8123 | localhost:18123 | `Skill(devops-tools:clickhouse-cloud-management)` |
 | VNC (MT5)  | gpu-host-1 | 5900 | localhost:5900  | x11vnc, display :99, MT5/WINE                     |
 
@@ -117,6 +117,8 @@ Skip rules in the PostToolUse hook prevent nag-loops:
 
 ## Environment Variables
 
-| Variable        | Required | Description                                                                                                                                                         |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MINIMAX_MODEL` | No       | MiniMax model ID for `session-debrief` and `prompt-benchmark`; SSoT is `~/.config/mise/config.toml`; default `MiniMax-M3` (switched from M2.7-highspeed 2026-06-01) |
+| Variable        | Required | Description                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MINIMAX_MODEL` | No       | MiniMax model ID, default `MiniMax-M3`. SSoT is the shell export at `~/.claude/tools/toolchain/path.sh` (declared in that toolchain's `manifest.toml`), sourced from `~/.zshenv`. **Read only by `plugins/minimax/scripts/m3-cli.ts` and the TTS companion's `Config.swift`** — both of which hardcode the same `MiniMax-M3` fallback anyway. |
+
+> **Corrected 2026-09-05, two errors in the row above.** (1) It named `~/.config/mise/config.toml` as the SSoT. That path **does not exist** and mise is not installed on this machine at all; the export moved into `path.sh` on 2026-08-21 when mise was retired. (2) It claimed the variable configures `session-debrief` and `prompt-benchmark`. It does not: `scripts/session-debrief.ts:91` and `scripts/prompt-benchmark.ts:83` both declare a const _named_ `MINIMAX_MODEL` but assign it from `process.env.DEBRIEF_LLM_MODEL ?? "claude-sonnet-5[1m]"`. Nothing anywhere sets `DEBRIEF_LLM_MODEL`, so both scripts always run on the hardcoded Claude model and setting `MINIMAX_MODEL` has zero effect on them. The misleading const name is the likely origin of the error. `skills/session-debrief/SKILL.md` carries the same stale claim.

--- a/plugins/devops-tools/skills/session-debrief/SKILL.md
+++ b/plugins/devops-tools/skills/session-debrief/SKILL.md
@@ -157,14 +157,14 @@ bun run $HOME/eon/cc-skills/plugins/devops-tools/scripts/session-debrief.ts \
 
 ## Configuration
 
-| Setting             | Source                                                           | Default                   |
-| ------------------- | ---------------------------------------------------------------- | ------------------------- |
-| MiniMax API key     | `~/.claude/.secrets/ccterrybot-telegram` (`MINIMAX_API_KEY=...`) | Required                  |
-| Model               | `MINIMAX_MODEL` env var (global mise config)                     | `MiniMax-M2.7-highspeed`  |
-| Max output tokens   | Hardcoded                                                        | 16384 per call            |
-| Context budget      | Hardcoded                                                        | 890K chars (~243K tokens) |
-| Default time window | `--since`                                                        | 48 hours                  |
-| Session chaining    | `--no-chain` to disable                                          | Enabled                   |
+| Setting             | Source                                                               | Default                   |
+| ------------------- | -------------------------------------------------------------------- | ------------------------- |
+| MiniMax API key     | `~/.claude/.secrets/ccterrybot-telegram` (`MINIMAX_API_KEY=...`)     | Required                  |
+| Model               | `DEBRIEF_LLM_MODEL` env var (nothing sets it; effectively hardcoded) | `claude-sonnet-5[1m]`     |
+| Max output tokens   | Hardcoded                                                            | 16384 per call            |
+| Context budget      | Hardcoded                                                            | 890K chars (~243K tokens) |
+| Default time window | `--since`                                                            | 48 hours                  |
+| Session chaining    | `--no-chain` to disable                                              | Enabled                   |
 
 ---
 

--- a/plugins/gh-tools/CLAUDE.md
+++ b/plugins/gh-tools/CLAUDE.md
@@ -203,7 +203,9 @@ No individual IDs need to be listed separately — the full paths are strictly m
 
 ## GitHub Issues as Insight Repository
 
-**CRITICAL**: Only post to repositories owned by `terrylica` (your own repos or forks). NEVER post to upstream third-party repositories.
+**CRITICAL**: NEVER post to upstream third-party repositories. Which owner you _may_ write to is **not** a fixed account — it is decided per filesystem path by this plugin's own `hooks/pretooluse-path-owner-guard.mjs` (registered on `PreToolUse`/`Bash` in [hooks.json](./hooks/hooks.json)), which resolves the expected owner via `resolveExpectedOwner()` in [`hooks/lib/path-owner-registry.mjs`](./hooks/lib/path-owner-registry.mjs) against the machine-readable SSoT `~/.claude/path-owner-registry.toml` (longest matching `path_prefix` wins, plus per-prefix `allow_orgs`). **That registry is the SSoT — read it, do not restate it here.** Escape hatch: `ALLOW_OWNER_MISMATCH=1`.
+
+> **Corrected 2026-09-05.** This line used to read "Only post to repositories owned by `terrylica`", which is both **narrower than reality** and redundant with the shipped guard. `~/vj` maps to `vanjobbers` and `~/own` to `tainora`; `~/eon` defaults to `terrylica` but allows the `Eon-Labs` / `EonLabs-Spartan` orgs, and `~/eon/collab` / `~/vj/collab` admit named external collaborator owners. Following the old prose literally would have blocked legitimate pushes under `~/vj` and `~/own`.
 
 **Philosophy**: Treat GitHub Issues as human-readable insight repository for research and findings.
 
@@ -211,12 +213,12 @@ No individual IDs need to be listed separately — the full paths are strictly m
 
 ### When to Post Issue Comments
 
-| Action                  | Safe to Post?            | Example                                                    |
-| ----------------------- | ------------------------ | ---------------------------------------------------------- |
-| Your own repository     | Always                   | `terrylica/cc-skills`, `terrylica/data-source-manager`     |
-| Your fork               | Always                   | `terrylica/claude-code` (fork of `anthropics/claude-code`) |
-| Upstream third-party    | NEVER (read-only)        | `anthropics/claude-code`, `jdx/mise`                       |
-| Collaborative team repo | If you have write access | Repos where you're a collaborator                          |
+| Action                   | Safe to Post?                                 | Example                                                     |
+| ------------------------ | --------------------------------------------- | ----------------------------------------------------------- |
+| Repo under a mapped path | Yes — as that path's registered owner         | `~/eon`→`terrylica`, `~/vj`→`vanjobbers`, `~/own`→`tainora` |
+| Your fork                | Always                                        | `terrylica/claude-code` (fork of `anthropics/claude-code`)  |
+| Upstream third-party     | NEVER (read-only)                             | `anthropics/claude-code`, `jdx/mise`                        |
+| Collaborative team repo  | If the prefix's `allow_orgs` lists that owner | `~/eon/collab`, `~/vj/collab` external-collaborator owners  |
 
 ### Best Practices
 
@@ -241,7 +243,7 @@ No individual IDs need to be listed separately — the full paths are strictly m
 4. Reference upstream Issue: "Investigation of anthropics/claude-code#22055 revealed..."
 5. Post follow-up findings as comments in YOUR repo's Issue
 
-**Repositories you own**: `terrylica/*` (verify with `gh repo list terrylica`)
+**Which owner applies here**: resolve it from the path, don't assume — `~/.claude/path-owner-registry.toml` is the SSoT, and `gh repo list <owner>` verifies once you know the owner.
 
 ## Multi-Account Authentication (host-alias model, ADR 2026-06-21)
 

--- a/plugins/link-tools/README.md
+++ b/plugins/link-tools/README.md
@@ -1,9 +1,9 @@
 # link-tools
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/Skills-2-blue.svg)]()
-[![Hooks](https://img.shields.io/badge/Hooks-0-gray.svg)]()
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)]()
+[![Skills](https://img.shields.io/badge/Skills-2-blue.svg)](<>)
+[![Hooks](https://img.shields.io/badge/Hooks-0-gray.svg)](<>)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg)](<>)
 
 Comprehensive link validation for Claude Code: portability checks, lychee broken link detection, and path policy linting.
 
@@ -44,7 +44,7 @@ uv run plugins/link-tools/scripts/validate_links.py ./skills/
 
 - Detects absolute filesystem paths (`/Users/...`)
 - Validates relative path usage in plugins
-- Ensures links work after installation to `~/.claude/skills/`
+- Ensures links still resolve after install, under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/` — the version segment changes every release, so absolute paths rot
 
 ### Broken Link Detection (link-validation)
 

--- a/plugins/minimax/scripts/m3-cli.ts
+++ b/plugins/minimax/scripts/m3-cli.ts
@@ -9,8 +9,9 @@
  *
  * Pure Bun port of the former scripts/m3-{verify,probe,context-probe,bench}.py — no
  * Python / uv / requests / pillow runtime. The model under test is read dynamically
- * from the SSoT (MINIMAX_MODEL env, set by ~/.config/mise/config.toml); a prior model
- * version is never pinned in code.
+ * from the SSoT (MINIMAX_MODEL env, exported by ~/.claude/tools/toolchain/path.sh —
+ * moved there 2026-08-21 when mise was retired); a prior model version is never
+ * pinned in code.
  *
  * Key: MINIMAX_API_KEY env, else `op read` (MINIMAX_API_KEY_OP_PATH + MINIMAX_OP_ACCOUNT).
  * Proxy is bypassed in-process (MiniMax 502s through the local proxy) so callers need


### PR DESCRIPTION
## What changed, and why

Four pieces of guidance were re-measured against the world they describe. All four were wrong about their **reason**; three were still right about their **rule**. So in three cases the rule was kept or narrowed and the reason corrected, rather than the guidance being deleted.

That distinction is the whole point: a rotted reason is dangerous in both directions — it invites deleting a rule that is still needed, and it hides a rule that is actively wrong.

## Evidence

| Claim | Measured output | Source |
| --- | --- | --- |
| The zsh parse failure the shell rule cites no longer reproduces | `FOO=$(echo bar) env \| grep '^FOO='` → `FOO=bar` (exit 0); `VAR=$(echo hello) && echo "got $VAR"` → `got hello`; `if [[ -f /etc/hosts ]]` → `ok` | measured on zsh 5.9 this session |
| …but the rule is not entirely dead | `${V,,}` → `(eval):1: bad substitution` | same |
| Skills are not installed where the link rule says | `~/.claude/skills/` holds only hand-authored personal skills, zero marketplace plugins; `cc-plugin-root gh-tools` → `…/plugins/cache/cc-skills/gh-tools/30.0.0`, with seven orphaned sibling versions | measured this session |
| The gh-tools ownership rule is narrower than the guard in the same plugin | `pretooluse-path-owner-guard.mjs` is registered on `PreToolUse`/`Bash` and longest-prefix-matches `~/.claude/path-owner-registry.toml`, which maps `~/vj`→vanjobbers and `~/own`→tainora | plugin source + registry |
| ZeroTier is gone, per the file's own linked SSoT | "ZeroTier (removed 2026-04-06 due to macOS kernel-extension fragility)" | `plugins/ssh-tunnel-companion/CLAUDE.md:11` |
| `MINIMAX_MODEL` does not come from mise | `~/.config/mise/config.toml` → No such file or directory. `~/.claude/tools/toolchain/path.sh:132-133` → `MINIMAX_MODEL="${MINIMAX_MODEL:-MiniMax-M3}"` / `export MINIMAX_MODEL` | verified directly |

## What was kept rather than deleted

- **Shell compatibility**: narrowed to the syntax that genuinely breaks (`${var,,}`, `mapfile`, `declare -n`), with the blanket command-substitution claim marked superseded and the re-measurement inline. The ADR is untouched — it is a historical record and rewriting it would falsify the incident.
- **Relative links**: the rule stands; only the reason changed. Fixed at **all four sites** (`plugins/CLAUDE.md`, `README.md` twice, `plugins/link-tools/README.md`) because fixing one leaves the repo contradicting itself.
- **gh-tools**: the still-true part (never post upstream) is kept; the terrylica-only claim now points at the guard and registry as SSoT. This one was not merely redundant — it would have discouraged legitimate pushes under two of the three mapped roots.

## Recorded, not fixed

While tracing `MINIMAX_MODEL` a second defect surfaced: the same table claims it configures `session-debrief` and `prompt-benchmark`, but both declare a constant *named* `MINIMAX_MODEL` while assigning from `process.env.DEBRIEF_LLM_MODEL ?? "claude-sonnet-5[1m]"`. Nothing sets `DEBRIEF_LLM_MODEL`, so the variable has **zero effect** on either script. A variable documented as configuration but read under a different name is worse than an undocumented one. Noted in #146 rather than fixed here, since it is a behaviour change.

## Scope note

Two files outside `docs/` are touched — `Config.swift:100` and `minimax/scripts/m3-cli.ts:12`. Both are **comment-only**, correcting the same stale `~/.config/mise/config.toml` attribution so the fix is consistent everywhere the claim appears rather than only where it was most visible.

## Verification

```console
$ moon run repo:check > /tmp/g-rr.log 2>&1; echo "REAL EXIT = $?"
REAL EXIT = 0
repo:test-hooks | Test files PASSED:     114
repo:test-hooks | Test files FAILED:     0
Tasks: 6 completed
```

Exit code captured by redirect, never through a pipe. An earlier run of this gate failed `test-iter174` / `test-iter181` — the wall-clock-cap flake strand documented in #142, which passes standalone and is unrelated to any file here.

The diff was also scanned for credentials before commit (0 matches), because tracing the `MINIMAX_MODEL` provenance involved reading environment configuration.

Closes #146
