### PR TITLE
docs(mql5): record the measured mql5.com rate limit

### DIFF
--- a/plugins/mql5/skills/article-extractor/references/evolution-log.md
+++ b/plugins/mql5/skills/article-extractor/references/evolution-log.md
@@ -4,6 +4,30 @@
 
 ---
 
+## 2026-09-04: 🔴 mql5.com rate limit MEASURED — sequential-at-2s got the IP blocked
+
+**The repo's cardinal rule was incomplete.** It said "NEVER run parallel extractions from MQL5.com — triggers 24h+ IP blocks", which reads as though _concurrency_ is the trigger. It is not the only one. A **strictly sequential** attachment backfill at the configured 2-second rate limit (~13 req/min, one connection, one request in flight) was blocked after **212 requests / ~16 minutes**. Volume matters as much as concurrency.
+
+**What a block looks like** (worth recognising, because it is not an HTTP status): the first symptom was a plain `403` on one file. Afterwards, a single request to a URL that had returned `200` minutes earlier produced an HTTP/2 `PROTOCOL_ERROR` with no status at all, and over HTTP/1.1 `curl: (52) Empty reply from server`. The server accepts the TCP connection and closes without answering — enforcement is at the connection layer, not the application layer.
+
+**Where the 2 s came from:** `config.yaml` `batch.rate_limit_seconds: 2`, present since the initial commit with the comment "be respectful to server". Nothing in the repo ever measured it. The recon agent flagged exactly this ("I found no measurement of mql5.com's actual threshold anywhere in the repo") and the run went ahead on the inherited number anyway. That was the mistake.
+
+**Fixes applied to `scripts/backfill_attachments.py`:**
+
+- default rate 2 s → **8 s** (~7.5 req/min), and `--max-requests 150` bounds one session, so bulk work is spread over several short sessions instead of one long one
+- a `403` no longer aborts by itself: the script probes a known-good URL first and only aborts if that _also_ fails. Previously one restricted file halted the 434 remaining articles
+- progress is flushed, so a backgrounded run is observable (the first run's log looked empty for 16 minutes because Python buffers a non-TTY stdout)
+
+**State when it stopped:** 164 of 598 articles complete, 434 pending, 0 metadata parse failures across all 747 files, language `--verify` still PASS, 82 tests green. The job is resumable — an article counts as done only when every attachment entry has a terminal state — so nothing has to be re-fetched. Wait out the block before continuing.
+
+**Also fixed here:** the extractor left un-fetched grouped ZIPs with neither `local_path` nor `skipped_reason`, an indeterminate state that made "is this article complete?" unanswerable from metadata alone. Every attachment entry now ends in a terminal state.
+
+**Correction to yesterday's entry:** the claim that Chromium is "needed by `discovery.py` only" — written into four docs — is **false**. Six other call sites launch it (`scripts/extract_complete_docs_playwright.py`, three `scripts/legacy/*.py`, and the two network-marked tests). Corrected in `setup.sh`, `CLAUDE.md`, `README.md`, `lib/CLAUDE.md`.
+
+**Discovery XHR: investigated, NOT shipped.** `LoadPublications(this,'articles')` resolves to a plain `GET /en/users/<User>/publications/articles` with no offset, token or session state, returning the list as one HTML fragment. Live test: 77 articles vs 10 on page 1, zero overlap. **But the page advertises "107 more", so 10+107=117 ≠ 87, and the 30-article shortfall is unexplained** (plausibly translations, unverified). Replacing Playwright on that evidence would risk silently dropping articles, so discovery keeps the browser until the count reconciles.
+
+---
+
 ## 2026-09-03 (later): Adversarial review of the above — six real defects found and fixed
 
 An adversarial review pass over the changes below found that several of them were wrong or incomplete. Recording what the first pass got wrong, because most of it was self-verification that could not fail.


### PR DESCRIPTION
Closes #152.

Records the first measured datum this repo has on mql5.com's actual rate-limit threshold, in the `article-extractor` skill's evolution log.

## The correction

The skill's cardinal constraint reads *"NEVER run parallel extractions from MQL5.com — triggers 24h+ IP blocks"*, which implies **concurrency** is the trigger. A **strictly sequential** backfill — one connection, one request in flight, at the shipped `batch.rate_limit_seconds: 2` (~13 req/min) — was blocked after **212 requests / ~16 minutes**. Volume matters as much as concurrency.

The 2-second figure had been in `config.yaml` since the initial commit, commented *"be respectful to server"*, and was never measured. A recon agent flagged exactly that gap beforehand and the run proceeded on the inherited number anyway. That is recorded in the entry, because the process failure is the reusable part.

## Why the block is easy to misdiagnose

It is not an HTTP status. First a `403` on one file; afterwards a request to a URL that returned `200` minutes earlier yields an HTTP/2 `PROTOCOL_ERROR` with no status, and over HTTP/1.1 `curl: (52) Empty reply from server`. The server accepts the connection and closes without answering.

That places enforcement at the **connection layer**. [RFC 9113 §5.4.1](https://www.rfc-editor.org/rfc/rfc9113#section-5.4.1), verbatim:

> A connection error is any error that prevents further processing of the frame layer or corrupts any connection state. An endpoint that encounters a connection error SHOULD first send a GOAWAY frame (Section 6.8) with the stream identifier of the last stream that it successfully received from its peer.

and [§7](https://www.rfc-editor.org/rfc/rfc9113#section-7):

> `PROTOCOL_ERROR (0x01)`: The endpoint detected an unspecific protocol error. This error is for use when a more specific error code is not available.

A client inspecting only status codes sees nothing actionable, which is why a retry loop makes it worse rather than recovering.

## Also in this entry

- **Fixes shipped alongside**: default rate 2 s → 8 s, `--max-requests 150` to bound a session, and a `403`-vs-block canary so one restricted file no longer aborts the remaining 434 articles.
- **A correction to the previous entry**: the claim that Chromium is "needed by `discovery.py` only" was **false** — six other call sites launch it. Corrected in four docs.
- **A negative result, deliberately not shipped**: the discovery XHR (`LoadPublications`) resolves to a plain paginated GET and returned 77 articles vs 10 on page 1 with zero overlap — but the page advertises "107 more", so 10 + 107 ≠ 87 and the 30-article shortfall is unexplained. Replacing Playwright on that evidence risks silently dropping articles, so discovery keeps the browser until the count reconciles.

## Provenance

The branch has existed since 2026-09-08 but **no PR was ever opened for it** — found during worktree housekeeping, when `evolution-log.md` on `main` turned out to still be at its base commit. This PR lands work that was otherwise sitting unmerged on a remote branch.
